### PR TITLE
Remove extra '--' [HZ-4549]

### DIFF
--- a/hazelcast-enterprise.txt
+++ b/hazelcast-enterprise.txt
@@ -452,7 +452,6 @@ CodeSamples_URL:
 CodeSamples_Size:
 Github:
 ---
----
 ========== Development: SHOW
 ---
 Version: 5.4.0-BETA-2

--- a/hazelcast-open-source.txt
+++ b/hazelcast-open-source.txt
@@ -452,7 +452,6 @@ CodeSamples_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0/h
 CodeSamples_Size: 45 MB
 Github: https://github.com/hazelcast/hazelcast/tree/v5.0
 ---
----
 ========== Development: SHOW
 ---
 Version: 5.4.0-BETA-2


### PR DESCRIPTION
Directly removing the additional '---'
These were introduced way back in 
OS: [hazelcast-open-source.txt](https://github.com/hazelcast/rel-scripts/blob/9df9a7ca2890eb5f249bd0da9ba320fa7e580d3b/hazelcast-open-source.txt) 

EE: [hazelcast-enterprise.txt](https://github.com/hazelcast/rel-scripts/blob/96d7fbe408da94d3eb05bb660de8b2921ef544c0/hazelcast-enterprise.txt)

I have tested this in Staging and seems ok (created test 5.5.0 release)

https://github.com/hz-devops-test/rel-scripts/blob/master/hazelcast-enterprise.txt
https://github.com/hz-devops-test/rel-scripts/blob/master/hazelcast-open-source.txt

Release 5.5.0

![image](https://github.com/hazelcast/rel-scripts/assets/12186256/c0ed909e-d209-4708-955c-5405ab7e7d5f)

No extra '---'

![image](https://github.com/hazelcast/rel-scripts/assets/12186256/3e1e5e3e-4771-4d04-bb1e-98cc3dcc7423)

This worked so no need to update code I believe

Also commented here https://hazelcast.atlassian.net/browse/HZ-4549?focusedCommentId=94777

note: no back-porting required as this is on master