### PR TITLE
Test URLs are valid at PR time [DI-334]

### DIFF
--- a/.github/workflows/check-new-links.yml
+++ b/.github/workflows/check-new-links.yml
@@ -1,0 +1,40 @@
+name: Check new links
+
+on:
+  pull_request:
+
+jobs:
+  check_urls:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find changed lines
+        id: changed_lines
+        uses: hestonhoffman/changed-lines@v1
+        with:
+          file_filter: .txt
+
+      - name: Find any URLs in new lines and check they are resolvable
+        run: |
+          echo '${{ steps.changed_lines.outputs.changed_lines }}' | jq --raw-output 'to_entries | .[] | "\(.key): \(.value | join(", "))"' | while read line; do
+            file=$(echo "$line" | cut -d: -f1)
+            lines=$(echo "$line" | cut -d: -f2)
+
+            IFS=',' read -r -a line_numbers <<< "$lines"
+            for line_number in "${line_numbers[@]}"; do
+              # Extract anything that looks like a URL - we don't want to be too strict, we *want* to catch invalid URLs
+              url=$(sed -n "${line_number}p" "$file" | grep --extended-regexp --only-matching '[^[:space:]]*https?://[^[:space:]]*' || true)
+
+              if [[ -n "${url}" ]]; then
+                  status=$(curl --output /dev/null --location --head --write-out "%{http_code}" "${url}" || true)
+
+                  if [[ "${status}" == "200" ]]; then
+                    echo "✅ ${url}"
+                  else
+                    echo "::error::❌ URL '${url}' in ${file} had status ${status}" 1>&2
+                    exit 1
+                  fi
+              fi
+            done
+          done


### PR DESCRIPTION
The post-release checklist includes a manual check for the download links - validated by spotting [an error]( https://github.com/hazelcast/rel-scripts/commit/013b2d54ec3076221e6f352d4d9228e1c0047ff8#diff-0ae958136aed79d39220a53fc0899485e646ddb3f63a524771a41669de1c4686R14) in a URL.

These checks can instead be automated.

Added an action that, on a PR, tests the updated _lines_ for URL-alike content, and if found, tests they actually resolve - flagging those that don't.
It doesn't test _all_ the content because some links don't work on purpose - e.g. the [5.4.0-BETA-2](https://github.com/hazelcast/rel-scripts/blob/49b2bc718df3f1a8c5d8095e168728a21a1e4101/hazelcast-open-source.txt#L531C19-L531C116) URL is listed in a (now hidden) section, but the content has since been deleted. But we can assume when _adding_ new content, the links should at least work at that point.

This is triggered by a `pull_request`, but the release pipeline `push`es directly. Although we _could_ trigger based on `push`, it would be unhelpful to notify a bot GitHub Actor of a failure, so this is an _additional_ check alongside the manual one.

Execution examples:
- [Success](https://github.com/JackPGreen/rel-scripts/actions/runs/11712124649/job/32622121495)
- [Failure](https://github.com/JackPGreen/rel-scripts/actions/runs/11711877446) (with error from https://github.com/hazelcast/rel-scripts/commit/013b2d54ec3076221e6f352d4d9228e1c0047ff8)

Fixes: [DI-334](https://hazelcast.atlassian.net/browse/DI-334)

[DI-334]: https://hazelcast.atlassian.net/browse/DI-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ