### PR TITLE
Update (now dead) `jet-start.sh` links [OLDDOCS-708]

### DIFF
--- a/hub_projects/avro-connector.txt
+++ b/hub_projects/avro-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0 
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-avro/4.0/jar
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/files/src/main/java/com/hazelcast/jet/examples/files/avro 
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#apache-avro
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#avro
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/custom-connector-builder.txt
+++ b/hub_projects/custom-connector-builder.txt
@@ -3,7 +3,7 @@
 Version: 4.0
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/source-sink-builder 
-Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##custom-sources-and-sinks
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#custom-sources-and-sinks
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/custom-connector-builder.txt
+++ b/hub_projects/custom-connector-builder.txt
@@ -3,7 +3,7 @@
 Version: 4.0
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/source-sink-builder 
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#custom-sources-and-sinks
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##custom-sources-and-sinks
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/debezium-connector.txt
+++ b/hub_projects/debezium-connector.txt
@@ -2,7 +2,7 @@
 ---
 Version: 0.1  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet.contrib/debezium/0.1/jar 
-Code_Samples_URL: https://jet-start.sh/docs/tutorials/cdc
+Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/tutorials/cdc.md
 Docs_URL: https://github.com/hazelcast/hazelcast-jet-contrib/tree/master/debezium
 Learn_More_URL: 
 ---

--- a/hub_projects/file-connector.txt
+++ b/hub_projects/file-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/v4.0/examples/files/src/main/java/com/hazelcast/jet/examples/files/AccessLogAnalyzer.java
-Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##files
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#files
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/file-connector.txt
+++ b/hub_projects/file-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/v4.0/examples/files/src/main/java/com/hazelcast/jet/examples/files/AccessLogAnalyzer.java
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#files
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##files
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/hazelcast-icache-connector.txt
+++ b/hub_projects/hazelcast-icache-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0 
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/v4.0/examples/imdg-connectors/src/main/java/com/hazelcast/jet/examples/imdg/CacheSourceAndSink.java
-Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##icache
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#icache
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/hazelcast-icache-connector.txt
+++ b/hub_projects/hazelcast-icache-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0 
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/v4.0/examples/imdg-connectors/src/main/java/com/hazelcast/jet/examples/imdg/CacheSourceAndSink.java
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#icache
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##icache
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/hazelcast-ilist-connector.txt
+++ b/hub_projects/hazelcast-ilist-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/v4.0/examples/imdg-connectors/src/main/java/com/hazelcast/jet/examples/imdg/ListSourceAndSink.java
-Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##ilist
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#ilist
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/hazelcast-ilist-connector.txt
+++ b/hub_projects/hazelcast-ilist-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/v4.0/examples/imdg-connectors/src/main/java/com/hazelcast/jet/examples/imdg/ListSourceAndSink.java
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#ilist
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##ilist
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/hazelcast-imap-connector.txt
+++ b/hub_projects/hazelcast-imap-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/v4.0/examples/imdg-connectors/src/main/java/com/hazelcast/jet/examples/imdg/MapPredicateAndProjection.java
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#imap
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##imap
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/hazelcast-imap-connector.txt
+++ b/hub_projects/hazelcast-imap-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/blob/v4.0/examples/imdg-connectors/src/main/java/com/hazelcast/jet/examples/imdg/MapPredicateAndProjection.java
-Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##imap
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#imap
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/hdfs-connector.txt
+++ b/hub_projects/hdfs-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0 
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-hadoop/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/hadoop
-Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##hadoop-inputformatoutputformat
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#hadoop-inputformatoutputformat
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/hdfs-connector.txt
+++ b/hub_projects/hdfs-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0 
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-hadoop/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/hadoop
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#hadoop-inputformatoutputformat
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##hadoop-inputformatoutputformat
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/jdbc-connector.txt
+++ b/hub_projects/jdbc-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/jdbc
-Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##jdbc
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#jdbc
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/jdbc-connector.txt
+++ b/hub_projects/jdbc-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/jdbc
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#jdbc
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##jdbc
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/jms-connector.txt
+++ b/hub_projects/jms-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/jms
-Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##jms
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md#jms
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/jms-connector.txt
+++ b/hub_projects/jms-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0  
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet/4.0/jar 
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/jms
-Docs_URL: https://jet-start.sh/docs/api/sources-sinks#jms
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/api/sources-sinks.md##jms
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/hub_projects/kafka-connector.txt
+++ b/hub_projects/kafka-connector.txt
@@ -3,7 +3,7 @@
 Version: 4.0 
 Download_URL: https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-kafka/4.0/jar
 Code_Samples_URL: https://github.com/hazelcast/hazelcast-jet/tree/v4.0/examples/kafka
-Docs_URL: https://jet-start.sh/docs/tutorials/kafka
+Docs_URL: https://github.com/hazelcast/hazelcast-jet/blob/master/site/docs/tutorials/kafka.md
 Learn_More_URL: 
 ---
 ========== Previous Stable

--- a/jet-enterprise.txt
+++ b/jet-enterprise.txt
@@ -6,7 +6,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 669 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.5.4.tar.gz
 Download_TAR_Size: 669 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.4
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.4
@@ -22,7 +22,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 617 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.5.3.tar.gz
 Download_TAR_Size: 617 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.3
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.3
@@ -36,7 +36,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 617 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.5.2.tar.gz
 Download_TAR_Size: 617 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.2
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.2
@@ -50,7 +50,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 576 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.5.1.tar.gz
 Download_TAR_Size: 576 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.1
@@ -64,7 +64,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 573 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.5.tar.gz
 Download_TAR_Size: 573 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5
@@ -78,7 +78,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 562 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.4.tar.gz
 Download_TAR_Size: 562 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.4
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3
@@ -92,7 +92,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 109 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.3.1.tar.gz
 Download_TAR_Size: 109 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3.1
@@ -106,7 +106,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 103 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.3.tar.gz
 Download_TAR_Size: 103 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3
@@ -120,7 +120,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 103 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.2.tar.gz
 Download_TAR_Size: 103 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.2
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.2
@@ -134,7 +134,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 62 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.1.1.tar.gz
 Download_TAR_Size: 62 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1.1
@@ -148,7 +148,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 62 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.1.tar.gz
 Download_TAR_Size: 62 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1
@@ -162,7 +162,7 @@ Download_ZIP_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_ZIP_Size: 47 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.0.tar.gz
 Download_TAR_Size: 47 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.0
 ReleaseNotes: https://docs.hazelcast.org/docs/jet/release-notes/index.html#4-0

--- a/jet-enterprise.txt
+++ b/jet-enterprise.txt
@@ -67,7 +67,7 @@ Download_TAR_Size: 573 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5
-ReleaseNotes: https://jet-start.sh/blog/2021/04/21/jet-45-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
 Github:
@@ -81,7 +81,7 @@ Download_TAR_Size: 562 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.4
-ReleaseNotes: https://jet-start.sh/blog/2021/02/03/jet-44-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.4-maintenance/examples
 CodeSamples_Size:
 Github:
@@ -95,7 +95,7 @@ Download_TAR_Size: 109 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3.1
-ReleaseNotes: https://jet-start.sh/blog/2020/10/23/jet-43-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.3-maintenance/examples
 CodeSamples_Size:
 Github:
@@ -109,7 +109,7 @@ Download_TAR_Size: 103 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3
-ReleaseNotes: https://jet-start.sh/blog/2020/10/23/jet-43-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.3-maintenance/examples
 CodeSamples_Size:
 Github:
@@ -123,7 +123,7 @@ Download_TAR_Size: 103 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.2
-ReleaseNotes: https://jet-start.sh/blog/2020/07/14/jet-42-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.2
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.2-maintenance/examples
 CodeSamples_Size:
 Github:
@@ -137,7 +137,7 @@ Download_TAR_Size: 62 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1.1
-ReleaseNotes: https://jet-start.sh/blog/2020/04/29/jet-41-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
 Github:
@@ -151,7 +151,7 @@ Download_TAR_Size: 62 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1
-ReleaseNotes: https://jet-start.sh/blog/2020/04/29/jet-41-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
 Github:

--- a/jet-enterprise.txt
+++ b/jet-enterprise.txt
@@ -8,7 +8,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 669 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5.4
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.4
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.4
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -24,7 +24,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 617 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5.3
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.3
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.3
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -38,7 +38,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 617 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5.2
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.2
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.2
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -52,7 +52,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 576 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -66,7 +66,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 573 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5
 ReleaseNotes: https://jet-start.sh/blog/2021/04/21/jet-45-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -80,7 +80,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 562 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.4
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.4
 ReleaseNotes: https://jet-start.sh/blog/2021/02/03/jet-44-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.4-maintenance/examples
 CodeSamples_Size:
@@ -94,7 +94,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 109 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.3.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3.1
 ReleaseNotes: https://jet-start.sh/blog/2020/10/23/jet-43-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.3-maintenance/examples
 CodeSamples_Size:
@@ -108,7 +108,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 103 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.3
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3
 ReleaseNotes: https://jet-start.sh/blog/2020/10/23/jet-43-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.3-maintenance/examples
 CodeSamples_Size:
@@ -122,7 +122,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 103 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.2
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.2
 ReleaseNotes: https://jet-start.sh/blog/2020/07/14/jet-42-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.2-maintenance/examples
 CodeSamples_Size:
@@ -136,7 +136,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 62 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.1.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1.1
 ReleaseNotes: https://jet-start.sh/blog/2020/04/29/jet-41-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
@@ -150,7 +150,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 62 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1
 ReleaseNotes: https://jet-start.sh/blog/2020/04/29/jet-41-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
@@ -164,7 +164,7 @@ Download_TAR_URL: https://repository.hazelcast.com/download/jet-enterprise/hazel
 Download_TAR_Size: 47 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.0
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.0
 ReleaseNotes: https://docs.hazelcast.org/docs/jet/release-notes/index.html#4-0
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.0-maintenance/examples
 CodeSamples_Size:

--- a/jet-open-source.txt
+++ b/jet-open-source.txt
@@ -150,7 +150,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 61 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
@@ -164,7 +164,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 45 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.0
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.0
 ReleaseNotes: https://docs.hazelcast.org/docs/jet/release-notes/index.html#4-0
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.0-maintenance/examples
 CodeSamples_Size:

--- a/jet-open-source.txt
+++ b/jet-open-source.txt
@@ -6,7 +6,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 655 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.5.4/hazelcast-jet-4.5.4.tar.gz
 Download_TAR_Size: 655 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.4
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.4
@@ -22,7 +22,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 602 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.5.3/hazelcast-jet-4.5.3.tar.gz
 Download_TAR_Size: 602 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.3
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.3
@@ -36,7 +36,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 602 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.5.2/hazelcast-jet-4.5.2.tar.gz
 Download_TAR_Size: 602 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.2
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.2
@@ -50,7 +50,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 561 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.5.1/hazelcast-jet-4.5.1.tar.gz
 Download_TAR_Size: 561 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.1
@@ -64,7 +64,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 558 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.5/hazelcast-jet-4.5.tar.gz
 Download_TAR_Size: 558 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5
@@ -78,7 +78,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 547 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.4/hazelcast-jet-4.4.tar.gz
 Download_TAR_Size: 547 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.4
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.4
@@ -92,7 +92,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 107 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.3.1/hazelcast-jet-4.3.1.tar.gz
 Download_TAR_Size: 107 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3.1
@@ -106,7 +106,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 102 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.3/hazelcast-jet-4.3.tar.gz
 Download_TAR_Size: 102 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3
@@ -120,7 +120,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 102 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.2/hazelcast-jet-4.2.tar.gz
 Download_TAR_Size: 102 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.2
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.2
@@ -134,7 +134,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 61 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.1.1/hazelcast-jet-4.1.1.tar.gz
 Download_TAR_Size: 61 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1.1
@@ -148,7 +148,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 61 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.1/hazelcast-jet-4.1.tar.gz
 Download_TAR_Size: 61 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1
@@ -162,7 +162,7 @@ Download_ZIP_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_ZIP_Size: 45 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v4.0/hazelcast-jet-4.0.tar.gz
 Download_TAR_Size: 45 MB
-Docs_HTML: https://jet-start.sh/docs
+Docs_HTML: https://github.com/hazelcast/hazelcast-jet/tree/master/site/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.0
 ReleaseNotes: https://docs.hazelcast.org/docs/jet/release-notes/index.html#4-0

--- a/jet-open-source.txt
+++ b/jet-open-source.txt
@@ -67,7 +67,7 @@ Download_TAR_Size: 558 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5
-ReleaseNotes: https://jet-start.sh/blog/2021/04/21/jet-45-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
 Github: https://github.com/hazelcast/hazelcast-jet/tree/v4.5
@@ -81,7 +81,7 @@ Download_TAR_Size: 547 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.4
-ReleaseNotes: https://jet-start.sh/blog/2021/02/03/jet-44-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.4
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.4-maintenance/examples
 CodeSamples_Size:
 Github: https://github.com/hazelcast/hazelcast-jet/tree/v4.4
@@ -95,7 +95,7 @@ Download_TAR_Size: 107 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3.1
-ReleaseNotes: https://jet-start.sh/blog/2020/10/23/jet-43-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.3-maintenance/examples
 CodeSamples_Size:
 Github: https://github.com/hazelcast/hazelcast-jet/tree/v4.3.1
@@ -109,7 +109,7 @@ Download_TAR_Size: 102 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3
-ReleaseNotes: https://jet-start.sh/blog/2020/10/23/jet-43-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.3
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.3-maintenance/examples
 CodeSamples_Size:
 Github: https://github.com/hazelcast/hazelcast-jet/tree/v4.3
@@ -123,7 +123,7 @@ Download_TAR_Size: 102 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.2
-ReleaseNotes: https://jet-start.sh/blog/2020/07/14/jet-42-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.2
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.2-maintenance/examples
 CodeSamples_Size:
 Github: https://github.com/hazelcast/hazelcast-jet/tree/v4.2
@@ -137,7 +137,7 @@ Download_TAR_Size: 61 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
 APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1.1
-ReleaseNotes: https://jet-start.sh/blog/2020/04/29/jet-41-is-released
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
 Github: https://github.com/hazelcast/hazelcast-jet/tree/v4.1.1
@@ -150,8 +150,8 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 61 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1
-ReleaseNotes: https://jet-start.sh/blog/2020/04/29/jet-41-is-released
+APIDocs: https://jet-start.sh/javadoc/4.1
+ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
 Github: https://github.com/hazelcast/hazelcast-jet/tree/v4.1
@@ -164,7 +164,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 45 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.0
+APIDocs: https://jet-start.sh/javadoc/4.0
 ReleaseNotes: https://docs.hazelcast.org/docs/jet/release-notes/index.html#4-0
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.0-maintenance/examples
 CodeSamples_Size:

--- a/jet-open-source.txt
+++ b/jet-open-source.txt
@@ -8,7 +8,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 655 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5.4
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.4
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.4
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -24,7 +24,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 602 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5.3
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.3
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.3
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -38,7 +38,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 602 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5.2
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.2
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.2
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -52,7 +52,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 561 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5.1
 ReleaseNotes: https://github.com/hazelcast/hazelcast-jet/releases/tag/v4.5.1
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -66,7 +66,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 558 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.5
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.5
 ReleaseNotes: https://jet-start.sh/blog/2021/04/21/jet-45-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.5-maintenance/examples
 CodeSamples_Size:
@@ -80,7 +80,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 547 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.4
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.4
 ReleaseNotes: https://jet-start.sh/blog/2021/02/03/jet-44-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.4-maintenance/examples
 CodeSamples_Size:
@@ -94,7 +94,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 107 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.3.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3.1
 ReleaseNotes: https://jet-start.sh/blog/2020/10/23/jet-43-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.3-maintenance/examples
 CodeSamples_Size:
@@ -108,7 +108,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 102 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.3
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.3
 ReleaseNotes: https://jet-start.sh/blog/2020/10/23/jet-43-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.3-maintenance/examples
 CodeSamples_Size:
@@ -122,7 +122,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 102 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.2
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.2
 ReleaseNotes: https://jet-start.sh/blog/2020/07/14/jet-42-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.2-maintenance/examples
 CodeSamples_Size:
@@ -136,7 +136,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 61 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.1.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1.1
 ReleaseNotes: https://jet-start.sh/blog/2020/04/29/jet-41-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
@@ -150,7 +150,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 61 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.1
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.1
 ReleaseNotes: https://jet-start.sh/blog/2020/04/29/jet-41-is-released
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.1-maintenance/examples
 CodeSamples_Size:
@@ -164,7 +164,7 @@ Download_TAR_URL: https://github.com/hazelcast/hazelcast-jet/releases/download/v
 Download_TAR_Size: 45 MB
 Docs_HTML: https://jet-start.sh/docs
 Docs_PDF:
-APIDocs: https://jet-start.sh/javadoc/4.0
+APIDocs: https://javadoc.io/doc/com.hazelcast.jet/hazelcast-jet/4.0
 ReleaseNotes: https://docs.hazelcast.org/docs/jet/release-notes/index.html#4-0
 CodeSamples: https://github.com/hazelcast/hazelcast-jet/tree/4.0-maintenance/examples
 CodeSamples_Size:


### PR DESCRIPTION
The `jet-start.sh` links no longer work.

Although Jet is deprecated, the links should still point to relevant content under our control - updated to use either:
- the backing sources in GitHub
- Javadoc produced from the public Maven artefacts

[Slack discussion](https://hazelcast.slack.com/archives/C035HQET5/p1734602815474379).

_Partially addresses_ [OLDDOCS-708](https://hazelcast.atlassian.net/browse/OLDDOCS-708)

[OLDDOCS-708]: https://hazelcast.atlassian.net/browse/OLDDOCS-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ