### PR TITLE
Remove Standalone client BETA release from the client releases imdg-clients.txt [DI-454]

### DIFF
--- a/imdg-clients.txt
+++ b/imdg-clients.txt
@@ -1,16 +1,3 @@
-========== Java Client Standalone
----
-Version: 5.5.0-BETA
-Date: 10/14/2024
-Download_OS: https://repo1.maven.org/maven2/com/hazelcast/hazelcast-java-client/5.5.0-BETA/hazelcast-java-client-5.5.0-BETA.jar
-Download_OS_Size: 6.1 MB
-Download_EE: https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-java-client/5.5.0-BETA/hazelcast-enterprise-java-client-5.5.0-BETA.jar
-Download_EE_Size: 6.42 MB
-Github:
-Docs: https://docs.hazelcast.com/hazelcast/5.5/clients/java
-APIDocs: https://docs.hazelcast.org/hazelcast-java-client/5.5.0-BETA/javadoc
-ReleaseNotes:
----
 ========== Java Client
 ---
 Version: 5.5.0


### PR DESCRIPTION
Remove Standalone client BETA release from the client releases imdg-clients.txt

It was decided to remove standalone client BETa from the released clients.