### PR TITLE
Fix file sizes

### DIFF
--- a/hazelcast-enterprise.txt
+++ b/hazelcast-enterprise.txt
@@ -23,13 +23,13 @@ Github:
 Version: 5.6.1
 Date: 03/25/2026
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.6.1.zip
-Download_ZIP_Size: 845 MB
+Download_ZIP_Size: 886 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.6.1-slim.zip
-Download_slim_ZIP_Size: 48 MB
+Download_slim_ZIP_Size: 49 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.6.1.tar.gz
-Download_TAR_Size: 845 MB
+Download_TAR_Size: 886 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.6.1-slim.tar.gz
-Download_slim_TAR_Size: 48 MB
+Download_slim_TAR_Size: 49 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.6/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.6.1/javadoc
@@ -43,13 +43,13 @@ Github:
 Version: 5.6.0
 Date: 10/15/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.6.0.zip
-Download_ZIP_Size: 839 MB
+Download_ZIP_Size: 880 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.6.0-slim.zip
-Download_slim_ZIP_Size: 47 MB
+Download_slim_ZIP_Size: 49 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.6.0.tar.gz
-Download_TAR_Size: 839 MB
+Download_TAR_Size: 880 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.6.0-slim.tar.gz
-Download_slim_TAR_Size: 47 MB
+Download_slim_TAR_Size: 49 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.6/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.6.0/javadoc
@@ -61,13 +61,13 @@ Github:
 Version: 5.5.9
 Date: 03/02/2026
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.9.zip
-Download_ZIP_Size: 828 MB
+Download_ZIP_Size: 867 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.9-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.9.tar.gz
-Download_TAR_Size: 828 MB
+Download_TAR_Size: 867 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.9-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.9/javadoc
@@ -79,13 +79,13 @@ Github:
 Version: 5.5.8
 Date: 11/12/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.8.zip
-Download_ZIP_Size: 829 MB
+Download_ZIP_Size: 868 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.8-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.8.tar.gz
-Download_TAR_Size: 829 MB
+Download_TAR_Size: 868 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.8-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.8/javadoc
@@ -97,13 +97,13 @@ Github:
 Version: 5.5.7
 Date: 07/22/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.7.zip
-Download_ZIP_Size: 768 MB
+Download_ZIP_Size: 804 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.7-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.7.tar.gz
-Download_TAR_Size: 768 MB
+Download_TAR_Size: 804 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.7-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.7/javadoc
@@ -115,13 +115,13 @@ Github:
 Version: 5.5.6
 Date: 05/19/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.6.zip
-Download_ZIP_Size: 767 MB
+Download_ZIP_Size: 804 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.6-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.6.tar.gz
-Download_TAR_Size: 767 MB
+Download_TAR_Size: 804 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.6-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.6/javadoc
@@ -133,13 +133,13 @@ Github:
 Version: 5.5.5
 Date: 03/19/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.5.zip
-Download_ZIP_Size: 767 MB
+Download_ZIP_Size: 804 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.5-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.5.tar.gz
-Download_TAR_Size: 767 MB
+Download_TAR_Size: 804 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.5-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.5/javadoc
@@ -151,13 +151,13 @@ Github:
 Version: 5.5.4
 Date: 02/19/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.4.zip
-Download_ZIP_Size: 767 MB
+Download_ZIP_Size: 804 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.4-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.4.tar.gz
-Download_TAR_Size: 767 MB
+Download_TAR_Size: 804 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.4-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.4/javadoc
@@ -169,13 +169,13 @@ Github:
 Version: 5.5.2
 Date: 10/17/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.2.zip
-Download_ZIP_Size: 761 MB
+Download_ZIP_Size: 797 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.2-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.2.tar.gz
-Download_TAR_Size: 761 MB
+Download_TAR_Size: 797 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.2-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.2/javadoc
@@ -187,13 +187,13 @@ Github:
 Version: 5.5.1
 Date: 09/13/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.1.zip
-Download_ZIP_Size: 739 MB
+Download_ZIP_Size: 775 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.1-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.1.tar.gz
-Download_TAR_Size: 739 MB
+Download_TAR_Size: 775 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.1-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.1/javadoc
@@ -205,13 +205,13 @@ Github:
 Version: 5.5.0
 Date: 07/26/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.0.zip
-Download_ZIP_Size: 739 MB
+Download_ZIP_Size: 775 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.0-slim.zip
-Download_slim_ZIP_Size: 46 MB
+Download_slim_ZIP_Size: 48 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.0.tar.gz
-Download_TAR_Size: 739 MB
+Download_TAR_Size: 775 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.5.0-slim.tar.gz
-Download_slim_TAR_Size: 46 MB
+Download_slim_TAR_Size: 48 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.5.0/javadoc
@@ -223,13 +223,13 @@ Github:
 Version: 5.4.4
 Date: 12/01/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.4.zip
-Download_ZIP_Size: 770 MB
+Download_ZIP_Size: 807 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.4-slim.zip
-Download_slim_ZIP_Size: 43 MB
+Download_slim_ZIP_Size: 45 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.4.tar.gz
-Download_TAR_Size: 770 MB
+Download_TAR_Size: 807 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.4-slim.tar.gz
-Download_slim_TAR_Size: 43 MB
+Download_slim_TAR_Size: 45 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.4/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.4.4/javadoc
@@ -241,13 +241,13 @@ Github:
 Version: 5.4.3
 Date: 08/26/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.3.zip
-Download_ZIP_Size: 712 MB
+Download_ZIP_Size: 746 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.3-slim.zip
-Download_slim_ZIP_Size: 43 MB
+Download_slim_ZIP_Size: 45 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.3.tar.gz
-Download_TAR_Size: 712 MB
+Download_TAR_Size: 746 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.3-slim.tar.gz
-Download_slim_TAR_Size: 43 MB
+Download_slim_TAR_Size: 45 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.4/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.4.3/javadoc
@@ -259,13 +259,13 @@ Github:
 Version: 5.4.2
 Date: 06/30/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.2.zip
-Download_ZIP_Size: 695 MB
+Download_ZIP_Size: 728 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.2-slim.zip
-Download_slim_ZIP_Size: 43 MB
+Download_slim_ZIP_Size: 45 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.2.tar.gz
-Download_TAR_Size: 695 MB
+Download_TAR_Size: 728 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.2-slim.tar.gz
-Download_slim_TAR_Size: 43 MB
+Download_slim_TAR_Size: 45 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.4/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/hazelcast-ee-docs/5.4.2/javadoc
@@ -277,13 +277,13 @@ Github:
 Version: 5.4.1
 Date: 07/11/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.1.zip
-Download_ZIP_Size: 683 MB
+Download_ZIP_Size: 715 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.1-slim.zip
-Download_slim_ZIP_Size: 43 MB
+Download_slim_ZIP_Size: 45 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.1.tar.gz
-Download_TAR_Size: 683 MB
+Download_TAR_Size: 715 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.1-slim.tar.gz
-Download_slim_TAR_Size: 43 MB
+Download_slim_TAR_Size: 45 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.4/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.4.1/javadoc
@@ -295,13 +295,13 @@ Github:
 Version: 5.4.0
 Date: 04/15/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.0.zip
-Download_ZIP_Size: 663 MB
+Download_ZIP_Size: 695 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.0-slim.zip
-Download_slim_ZIP_Size: 43 MB
+Download_slim_ZIP_Size: 45 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.0.tar.gz
-Download_TAR_Size: 663 MB
+Download_TAR_Size: 695 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.0-slim.tar.gz
-Download_slim_TAR_Size: 43 MB
+Download_slim_TAR_Size: 45 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.4/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.4.0/javadoc
@@ -313,13 +313,13 @@ Github:
 Version: 5.3.8
 Date: 07/17/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.8.zip
-Download_ZIP_Size: 564 MB
+Download_ZIP_Size: 590 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.8-slim.zip
-Download_slim_ZIP_Size: 40 MB
+Download_slim_ZIP_Size: 42 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.8.tar.gz
-Download_TAR_Size: 564 MB
+Download_TAR_Size: 590 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.8-slim.tar.gz
-Download_slim_TAR_Size: 40 MB
+Download_slim_TAR_Size: 42 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.8/javadoc
@@ -331,13 +331,13 @@ Github:
 Version: 5.3.7
 Date: 04/03/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.7.zip
-Download_ZIP_Size: 541 MB
+Download_ZIP_Size: 567 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.7-slim.zip
-Download_slim_ZIP_Size: 40 MB
+Download_slim_ZIP_Size: 42 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.7.tar.gz
-Download_TAR_Size: 541 MB
+Download_TAR_Size: 567 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.7-slim.tar.gz
-Download_slim_TAR_Size: 40 MB
+Download_slim_TAR_Size: 42 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.7/javadoc
@@ -349,13 +349,13 @@ Github:
 Version: 5.3.6
 Date: 11/09/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.6.zip
-Download_ZIP_Size: 542 MB
+Download_ZIP_Size: 568 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.6-slim.zip
-Download_slim_ZIP_Size: 40 MB
+Download_slim_ZIP_Size: 42 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.6.tar.gz
-Download_TAR_Size: 542 MB
+Download_TAR_Size: 568 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.6-slim.tar.gz
-Download_slim_TAR_Size: 40 MB
+Download_slim_TAR_Size: 42 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.6/javadoc
@@ -367,13 +367,13 @@ Github:
 Version: 5.3.5
 Date: 10/24/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.5.zip
-Download_ZIP_Size: 542 MB
+Download_ZIP_Size: 568 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.5-slim.zip
-Download_slim_ZIP_Size: 40 MB
+Download_slim_ZIP_Size: 42 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.5.tar.gz
-Download_TAR_Size: 542 MB
+Download_TAR_Size: 568 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.5-slim.tar.gz
-Download_slim_TAR_Size: 40 MB
+Download_slim_TAR_Size: 42 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.5/javadoc
@@ -385,13 +385,13 @@ Github:
 Version: 5.3.2
 Date: 08/21/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.2.zip
-Download_ZIP_Size: 548 MB
+Download_ZIP_Size: 574 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.2-slim.zip
-Download_slim_ZIP_Size: 40 MB
+Download_slim_ZIP_Size: 42 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.2.tar.gz
-Download_TAR_Size: 548 MB
+Download_TAR_Size: 574 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.2-slim.tar.gz
-Download_slim_TAR_Size: 40 MB
+Download_slim_TAR_Size: 41 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.2/javadoc
@@ -403,13 +403,13 @@ Github:
 Version: 5.3.1
 Date: 06/09/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.1.zip
-Download_ZIP_Size: 548 MB
+Download_ZIP_Size: 574 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.1-slim.zip
-Download_slim_ZIP_Size: 40 MB
+Download_slim_ZIP_Size: 41 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.1.tar.gz
-Download_TAR_Size: 548 MB
+Download_TAR_Size: 574 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.1-slim.tar.gz
-Download_slim_TAR_Size: 40 MB
+Download_slim_TAR_Size: 41 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.1/javadoc
@@ -421,13 +421,13 @@ Github:
 Version: 5.3.0
 Date: 05/19/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.0.zip
-Download_ZIP_Size: 547 MB
+Download_ZIP_Size: 573 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.0-slim.zip
-Download_slim_ZIP_Size: 40 MB
+Download_slim_ZIP_Size: 41 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.0.tar.gz
-Download_TAR_Size: 547 MB
+Download_TAR_Size: 573 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.3.0-slim.tar.gz
-Download_slim_TAR_Size: 40 MB
+Download_slim_TAR_Size: 41 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.0/javadoc
@@ -439,13 +439,13 @@ Github:
 Version: 5.2.5
 Date: 02/26/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.5.zip
-Download_ZIP_Size: 523 MB
+Download_ZIP_Size: 548 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.5-slim.zip
-Download_slim_ZIP_Size: 39 MB
+Download_slim_ZIP_Size: 40 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.5.tar.gz
-Download_TAR_Size: 523 MB
+Download_TAR_Size: 548 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.5-slim.tar.gz
-Download_slim_TAR_Size: 39 MB
+Download_slim_TAR_Size: 40 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.5/javadoc
@@ -457,13 +457,13 @@ Github:
 Version: 5.2.4
 Date: 06/13/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.4.zip
-Download_ZIP_Size: 519 MB
+Download_ZIP_Size: 544 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.4-slim.zip
-Download_slim_ZIP_Size: 39 MB
+Download_slim_ZIP_Size: 40 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.4.tar.gz
-Download_TAR_Size: 519 MB
+Download_TAR_Size: 544 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.4-slim.tar.gz
-Download_slim_TAR_Size: 39 MB
+Download_slim_TAR_Size: 40 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.4/javadoc
@@ -475,13 +475,13 @@ Github:
 Version: 5.2.3
 Date: 03/23/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.3.zip
-Download_ZIP_Size: 517 MB
+Download_ZIP_Size: 541 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.3-slim.zip
-Download_slim_ZIP_Size: 39 MB
+Download_slim_ZIP_Size: 40 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.3.tar.gz
-Download_TAR_Size: 517 MB
+Download_TAR_Size: 541 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.3-slim.tar.gz
-Download_slim_TAR_Size: 39 MB
+Download_slim_TAR_Size: 40 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.3/javadoc
@@ -493,13 +493,13 @@ Github:
 Version: 5.2.2
 Date: 02/15/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.2.zip
-Download_ZIP_Size: 516 MB
+Download_ZIP_Size: 540 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.2-slim.zip
-Download_slim_ZIP_Size: 38 MB
+Download_slim_ZIP_Size: 40 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.2.tar.gz
-Download_TAR_Size: 516 MB
+Download_TAR_Size: 540 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.2-slim.tar.gz
-Download_slim_TAR_Size: 38 MB
+Download_slim_TAR_Size: 40 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.2/javadoc
@@ -511,13 +511,13 @@ Github:
 Version: 5.2.1
 Date: 11/14/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.1.zip
-Download_ZIP_Size: 514 MB
+Download_ZIP_Size: 539 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.1-slim.zip
-Download_slim_ZIP_Size: 38 MB
+Download_slim_ZIP_Size: 40 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.1.tar.gz
-Download_TAR_Size: 514 MB
+Download_TAR_Size: 539 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.1-slim.tar.gz
-Download_slim_TAR_Size: 38 MB
+Download_slim_TAR_Size: 40 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.1/javadoc
@@ -529,13 +529,13 @@ Github:
 Version: 5.2.0
 Date: 10/25/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.0.zip
-Download_ZIP_Size: 509 MB
+Download_ZIP_Size: 534 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.0-slim.zip
-Download_slim_ZIP_Size: 37 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.0.tar.gz
-Download_TAR_Size: 509 MB
+Download_TAR_Size: 534 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.2.0-slim.tar.gz
-Download_slim_TAR_Size: 37 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.0/javadoc
@@ -547,13 +547,13 @@ Github:
 Version: 5.1.7
 Date: 06/19/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.7.zip
-Download_ZIP_Size: 476 MB
+Download_ZIP_Size: 499 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.7-slim.zip
-Download_slim_ZIP_Size: 38 MB
+Download_slim_ZIP_Size: 40 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.7.tar.gz
-Download_TAR_Size: 476 MB
+Download_TAR_Size: 499 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.7-slim.tar.gz
-Download_slim_TAR_Size: 38 MB
+Download_slim_TAR_Size: 39 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.7/javadoc
@@ -565,13 +565,13 @@ Github:
 Version: 5.1.6
 Date: 05/10/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.6.zip
-Download_ZIP_Size: 476 MB
+Download_ZIP_Size: 498 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.6-slim.zip
-Download_slim_ZIP_Size: 38 MB
+Download_slim_ZIP_Size: 39 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.6.tar.gz
-Download_TAR_Size: 476 MB
+Download_TAR_Size: 498 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.6-slim.tar.gz
-Download_slim_TAR_Size: 38 MB
+Download_slim_TAR_Size: 39 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.6/javadoc
@@ -583,13 +583,13 @@ Github:
 Version: 5.1.5
 Date: 11/14/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.5.zip
-Download_ZIP_Size: 474 MB
+Download_ZIP_Size: 496 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.5-slim.zip
-Download_slim_ZIP_Size: 38 MB
+Download_slim_ZIP_Size: 39 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.5.tar.gz
-Download_TAR_Size: 474 MB
+Download_TAR_Size: 496 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.5-slim.tar.gz
-Download_slim_TAR_Size: 38 MB
+Download_slim_TAR_Size: 39 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.5/javadoc
@@ -601,13 +601,13 @@ Github:
 Version: 5.1.4
 Date: 10/11/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.4.zip
-Download_ZIP_Size: 469 MB
+Download_ZIP_Size: 491 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.4-slim.zip
-Download_slim_ZIP_Size: 37 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.4.tar.gz
-Download_TAR_Size: 469 MB
+Download_TAR_Size: 491 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.4-slim.tar.gz
-Download_slim_TAR_Size: 37 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.4/javadoc
@@ -619,13 +619,13 @@ Github:
 Version: 5.1.3
 Date: 08/01/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.3.zip
-Download_ZIP_Size: 477 MB
+Download_ZIP_Size: 500 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.3-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.3.tar.gz
-Download_TAR_Size: 477 MB
+Download_TAR_Size: 500 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.3-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.3/javadoc
@@ -637,13 +637,13 @@ Github:
 Version: 5.1.2
 Date: 06/13/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.2.zip
-Download_ZIP_Size: 478 MB
+Download_ZIP_Size: 500 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.2-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.2.tar.gz
-Download_TAR_Size: 477 MB
+Download_TAR_Size: 500 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.2-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.2/javadoc
@@ -655,13 +655,13 @@ Github:
 Version: 5.1.1
 Date: 03/17/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.1.zip
-Download_ZIP_Size: 483 MB
+Download_ZIP_Size: 506 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.1-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.1.tar.gz
-Download_TAR_Size: 483 MB
+Download_TAR_Size: 506 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.1-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.1/javadoc
@@ -673,13 +673,13 @@ Github:
 Version: 5.1
 Date: 03/01/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.zip
-Download_ZIP_Size: 483 MB
+Download_ZIP_Size: 506 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1.tar.gz
-Download_TAR_Size: 483 MB
+Download_TAR_Size: 506 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.1-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1/javadoc
@@ -691,13 +691,13 @@ Github:
 Version: 5.0.5
 Date: 06/28/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.5.zip
-Download_ZIP_Size: 466 MB
+Download_ZIP_Size: 488 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.5-slim.zip
-Download_slim_ZIP_Size: 31 MB
+Download_slim_ZIP_Size: 32 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.5.tar.gz
-Download_TAR_Size: 466 MB
+Download_TAR_Size: 488 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.5-slim.tar.gz
-Download_slim_TAR_Size: 31 MB
+Download_slim_TAR_Size: 32 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.0.5/javadoc
@@ -709,13 +709,13 @@ Github:
 Version: 5.0.4
 Date: 11/24/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.4.zip
-Download_ZIP_Size: 466 MB
+Download_ZIP_Size: 488 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.4-slim.zip
-Download_slim_ZIP_Size: 31 MB
+Download_slim_ZIP_Size: 32 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.4.tar.gz
-Download_TAR_Size: 466 MB
+Download_TAR_Size: 488 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.4-slim.tar.gz
-Download_slim_TAR_Size: 31 MB
+Download_slim_TAR_Size: 32 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.0.4/javadoc
@@ -727,13 +727,13 @@ Github:
 Version: 5.0.3
 Date: 03/28/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.3.zip
-Download_ZIP_Size: 471 MB
+Download_ZIP_Size: 493 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.3-slim.zip
-Download_slim_ZIP_Size: 30 MB
+Download_slim_ZIP_Size: 31 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.3.tar.gz
-Download_TAR_Size: 471 MB
+Download_TAR_Size: 493 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.3-slim.tar.gz
-Download_slim_TAR_Size: 30 MB
+Download_slim_TAR_Size: 31 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.0.3/javadoc
@@ -745,13 +745,13 @@ Github:
 Version: 5.0.2
 Date: 12/21/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.2.zip
-Download_ZIP_Size: 724 MB
+Download_ZIP_Size: 759 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.2-slim.zip
 Download_slim_ZIP_Size: 30 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.2.tar.gz
-Download_TAR_Size: 724 MB
+Download_TAR_Size: 759 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.2-slim.tar.gz
-Download_slim_TAR_Size: 29 MB
+Download_slim_TAR_Size: 30 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.0.2/javadoc
@@ -763,13 +763,13 @@ Github:
 Version: 5.0.1
 Date: 12/17/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.1.zip
-Download_ZIP_Size: 724 MB
+Download_ZIP_Size: 758 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.1-slim.zip
 Download_slim_ZIP_Size: 30 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.1.tar.gz
-Download_TAR_Size: 724 MB
+Download_TAR_Size: 758 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.1-slim.tar.gz
-Download_slim_TAR_Size: 29 MB
+Download_slim_TAR_Size: 30 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.0.1/javadoc
@@ -781,13 +781,13 @@ Github:
 Version: 5.0
 Date: 09/22/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.zip
-Download_ZIP_Size: 681 MB
+Download_ZIP_Size: 714 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0-slim.zip
-Download_slim_ZIP_Size: 29 MB
+Download_slim_ZIP_Size: 30 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0.tar.gz
-Download_TAR_Size: 681 MB
+Download_TAR_Size: 714 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.0-slim.tar.gz
-Download_slim_TAR_Size: 29 MB
+Download_slim_TAR_Size: 30 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.0/javadoc
@@ -801,13 +801,13 @@ Github:
 Version: 5.4.0-BETA-2
 Date: 02/13/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.0-BETA-2.zip
-Download_ZIP_Size: 657 MB
+Download_ZIP_Size: 689 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.0-BETA-2-slim.zip
-Download_slim_ZIP_Size: 43 MB
+Download_slim_ZIP_Size: 45 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.0-BETA-2.tar.gz
-Download_TAR_Size: 657 MB
+Download_TAR_Size: 689 MB
 Download_slim_TAR_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.4.0-BETA-2-slim.tar.gz
-Download_slim_TAR_Size: 43 MB
+Download_slim_TAR_Size: 45 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.4/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.4.0-BETA-2/javadoc

--- a/hazelcast-open-source.txt
+++ b/hazelcast-open-source.txt
@@ -23,13 +23,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.7.0
 Version: 5.6.0
 Date: 10/15/2025
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.6.0/hazelcast-5.6.0.zip
-Download_ZIP_Size: 781 MB
+Download_ZIP_Size: 818 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.6.0/hazelcast-5.6.0-slim.zip
-Download_slim_ZIP_Size: 39 MB
+Download_slim_ZIP_Size: 41 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.6.0/hazelcast-5.6.0.tar.gz
-Download_TAR_Size: 781 MB
+Download_TAR_Size: 818 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.6.0/hazelcast-5.6.0-slim.tar.gz
-Download_slim_TAR_Size: 39 MB
+Download_slim_TAR_Size: 41 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.6/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.6.0/javadoc
@@ -43,13 +43,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.6.0
 Version: 5.5.0
 Date: 07/26/2024
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.5.0/hazelcast-5.5.0.zip
-Download_ZIP_Size: 695 MB
+Download_ZIP_Size: 728 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.5.0/hazelcast-5.5.0-slim.zip
-Download_slim_ZIP_Size: 39 MB
+Download_slim_ZIP_Size: 40 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.5.0/hazelcast-5.5.0.tar.gz
-Download_TAR_Size: 695 MB
+Download_TAR_Size: 728 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.5.0/hazelcast-5.5.0-slim.tar.gz
-Download_slim_TAR_Size: 39 MB
+Download_slim_TAR_Size: 40 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.5/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.5.0/javadoc
@@ -61,13 +61,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.5.0
 Version: 5.4.0
 Date: 04/15/2024
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.4.0/hazelcast-5.4.0.zip
-Download_ZIP_Size: 648 MB
+Download_ZIP_Size: 679 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.4.0/hazelcast-5.4.0-slim.zip
-Download_slim_ZIP_Size: 39 MB
+Download_slim_ZIP_Size: 41 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.4.0/hazelcast-5.4.0.tar.gz
-Download_TAR_Size: 648 MB
+Download_TAR_Size: 679 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.4.0/hazelcast-5.4.0-slim.tar.gz
-Download_slim_TAR_Size: 39 MB
+Download_slim_TAR_Size: 41 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.4/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.4.0/javadoc
@@ -79,13 +79,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.4.0
 Version: 5.3.8
 Date: 07/17/2024
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.8/hazelcast-5.3.8.zip
-Download_ZIP_Size: 577 MB
+Download_ZIP_Size: 605 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.8/hazelcast-5.3.8-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.8/hazelcast-5.3.8.tar.gz
-Download_TAR_Size: 577 MB
+Download_TAR_Size: 605 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.8/hazelcast-5.3.8-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.8/javadoc
@@ -97,13 +97,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.3.8
 Version: 5.3.7
 Date: 04/03/2024
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.7/hazelcast-5.3.7.zip
-Download_ZIP_Size: 554 MB
+Download_ZIP_Size: 580 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.7/hazelcast-5.3.7-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.7/hazelcast-5.3.7.tar.gz
-Download_TAR_Size: 554 MB
+Download_TAR_Size: 580 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.7/hazelcast-5.3.7-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.7/javadoc
@@ -115,13 +115,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.3.7
 Version: 5.3.6
 Date: 11/09/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.6/hazelcast-5.3.6.zip
-Download_ZIP_Size: 554 MB
+Download_ZIP_Size: 581 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.6/hazelcast-5.3.6-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.6/hazelcast-5.3.6.tar.gz
-Download_TAR_Size: 554 MB
+Download_TAR_Size: 581 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.6/hazelcast-5.3.6-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.6/javadoc
@@ -133,13 +133,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.3.6
 Version: 5.3.5
 Date: 10/24/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.5/hazelcast-5.3.5.zip
-Download_ZIP_Size: 554 MB
+Download_ZIP_Size: 581 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.5/hazelcast-5.3.5-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.5/hazelcast-5.3.5.tar.gz
-Download_TAR_Size: 554 MB
+Download_TAR_Size: 581 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.5/hazelcast-5.3.5-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.5/javadoc
@@ -151,13 +151,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.3.5
 Version: 5.3.2
 Date: 08/21/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.2/hazelcast-5.3.2.zip
-Download_ZIP_Size: 560 MB
+Download_ZIP_Size: 587 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.2/hazelcast-5.3.2-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.2/hazelcast-5.3.2.tar.gz
-Download_TAR_Size: 560 MB
+Download_TAR_Size: 587 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.2/hazelcast-5.3.2-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 38 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.2/javadoc
@@ -169,13 +169,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.3.2
 Version: 5.3.1
 Date: 06/09/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.1/hazelcast-5.3.1.zip
-Download_ZIP_Size: 560 MB
+Download_ZIP_Size: 586 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.1/hazelcast-5.3.1-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 38 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.1/hazelcast-5.3.1.tar.gz
-Download_TAR_Size: 560 MB
+Download_TAR_Size: 586 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.1/hazelcast-5.3.1-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 37 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.1/javadoc
@@ -187,13 +187,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.3.1
 Version: 5.3.0
 Date: 05/19/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.0/hazelcast-5.3.0.zip
-Download_ZIP_Size: 559 MB
+Download_ZIP_Size: 586 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.0/hazelcast-5.3.0-slim.zip
-Download_slim_ZIP_Size: 36 MB
+Download_slim_ZIP_Size: 37 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.0/hazelcast-5.3.0.tar.gz
-Download_TAR_Size: 559 MB
+Download_TAR_Size: 586 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.3.0/hazelcast-5.3.0-slim.tar.gz
-Download_slim_TAR_Size: 36 MB
+Download_slim_TAR_Size: 37 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.3/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.3.0/javadoc
@@ -205,13 +205,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.3.0
 Version: 5.2.5
 Date: 02/26/2024
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.5/hazelcast-5.2.5.zip
-Download_ZIP_Size: 530 MB
+Download_ZIP_Size: 555 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.5/hazelcast-5.2.5-slim.zip
-Download_slim_ZIP_Size: 35 MB
+Download_slim_ZIP_Size: 36 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.5/hazelcast-5.2.5.tar.gz
-Download_TAR_Size: 530 MB
+Download_TAR_Size: 555 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.5/hazelcast-5.2.5-slim.tar.gz
-Download_slim_TAR_Size: 35 MB
+Download_slim_TAR_Size: 36 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.5/javadoc
@@ -223,13 +223,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.2.5
 Version: 5.2.4
 Date: 06/13/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.4/hazelcast-5.2.4.zip
-Download_ZIP_Size: 525 MB
+Download_ZIP_Size: 550 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.4/hazelcast-5.2.4-slim.zip
-Download_slim_ZIP_Size: 35 MB
+Download_slim_ZIP_Size: 36 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.4/hazelcast-5.2.4.tar.gz
-Download_TAR_Size: 525 MB
+Download_TAR_Size: 550 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.4/hazelcast-5.2.4-slim.tar.gz
-Download_slim_TAR_Size: 35 MB
+Download_slim_TAR_Size: 36 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.4/javadoc
@@ -241,13 +241,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.2.4
 Version: 5.2.3
 Date: 03/23/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.3/hazelcast-5.2.3.zip
-Download_ZIP_Size: 523 MB
+Download_ZIP_Size: 548 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.3/hazelcast-5.2.3-slim.zip
-Download_slim_ZIP_Size: 35 MB
+Download_slim_ZIP_Size: 36 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.3/hazelcast-5.2.3.tar.gz
-Download_TAR_Size: 523 MB
+Download_TAR_Size: 548 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.3/hazelcast-5.2.3-slim.tar.gz
-Download_slim_TAR_Size: 35 MB
+Download_slim_TAR_Size: 36 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.3/javadoc
@@ -259,13 +259,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.2.3
 Version: 5.2.2
 Date: 02/15/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.2/hazelcast-5.2.2.zip
-Download_ZIP_Size: 522 MB
+Download_ZIP_Size: 547 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.2/hazelcast-5.2.2-slim.zip
-Download_slim_ZIP_Size: 35 MB
+Download_slim_ZIP_Size: 36 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.2/hazelcast-5.2.2.tar.gz
-Download_TAR_Size: 522 MB
+Download_TAR_Size: 547 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.2/hazelcast-5.2.2-slim.tar.gz
-Download_slim_TAR_Size: 35 MB
+Download_slim_TAR_Size: 36 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.2/javadoc
@@ -277,13 +277,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.2.2
 Version: 5.2.1
 Date: 11/14/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.1/hazelcast-5.2.1.zip
-Download_ZIP_Size: 521 MB
+Download_ZIP_Size: 545 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.1/hazelcast-5.2.1-slim.zip
-Download_slim_ZIP_Size: 35 MB
+Download_slim_ZIP_Size: 36 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.1/hazelcast-5.2.1.tar.gz
-Download_TAR_Size: 521 MB
+Download_TAR_Size: 545 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.1/hazelcast-5.2.1-slim.tar.gz
-Download_slim_TAR_Size: 35 MB
+Download_slim_TAR_Size: 36 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.1/javadoc
@@ -295,13 +295,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.2.1
 Version: 5.2.0
 Date: 10/25/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.0/hazelcast-5.2.0.zip
-Download_ZIP_Size: 516 MB
+Download_ZIP_Size: 540 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.0/hazelcast-5.2.0-slim.zip
-Download_slim_ZIP_Size: 33 MB
+Download_slim_ZIP_Size: 35 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.0/hazelcast-5.2.0.tar.gz
-Download_TAR_Size: 516 MB
+Download_TAR_Size: 540 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.2.0/hazelcast-5.2.0-slim.tar.gz
-Download_slim_TAR_Size: 33 MB
+Download_slim_TAR_Size: 34 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.2/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.2.0/javadoc
@@ -313,13 +313,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.2.0
 Version: 5.1.7
 Date: 06/19/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.7/hazelcast-5.1.7.zip
-Download_ZIP_Size: 480 MB
+Download_ZIP_Size: 502 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.7/hazelcast-5.1.7-slim.zip
-Download_slim_ZIP_Size: 35 MB
+Download_slim_ZIP_Size: 36 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.7/hazelcast-5.1.7.tar.gz
-Download_TAR_Size: 480 MB
+Download_TAR_Size: 502 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.7/hazelcast-5.1.7-slim.tar.gz
-Download_slim_TAR_Size: 35 MB
+Download_slim_TAR_Size: 36 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.7/javadoc
@@ -331,13 +331,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.1.7
 Version: 5.1.6
 Date: 05/10/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.6/hazelcast-5.1.6.zip
-Download_ZIP_Size: 479 MB
+Download_ZIP_Size: 502 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.6/hazelcast-5.1.6-slim.zip
-Download_slim_ZIP_Size: 35 MB
+Download_slim_ZIP_Size: 36 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.6/hazelcast-5.1.6.tar.gz
-Download_TAR_Size: 479 MB
+Download_TAR_Size: 502 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.6/hazelcast-5.1.6-slim.tar.gz
-Download_slim_TAR_Size: 34 MB
+Download_slim_TAR_Size: 36 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.6/javadoc
@@ -349,13 +349,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.1.6
 Version: 5.1.5
 Date: 11/14/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.5/hazelcast-5.1.5.zip
-Download_ZIP_Size: 477 MB
+Download_ZIP_Size: 500 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.5/hazelcast-5.1.5-slim.zip
-Download_slim_ZIP_Size: 34 MB
+Download_slim_ZIP_Size: 36 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.5/hazelcast-5.1.5.tar.gz
-Download_TAR_Size: 477 MB
+Download_TAR_Size: 499 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.5/hazelcast-5.1.5-slim.tar.gz
-Download_slim_TAR_Size: 34 MB
+Download_slim_TAR_Size: 35 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.5/javadoc
@@ -367,13 +367,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.1.5
 Version: 5.1.4
 Date: 10/11/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.4/hazelcast-5.1.4.zip
-Download_ZIP_Size: 472 MB
+Download_ZIP_Size: 495 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.4/hazelcast-5.1.4-slim.zip
-Download_slim_ZIP_Size: 33 MB
+Download_slim_ZIP_Size: 34 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.4/hazelcast-5.1.4.tar.gz
-Download_TAR_Size: 472 MB
+Download_TAR_Size: 495 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.4/hazelcast-5.1.4-slim.tar.gz
-Download_slim_TAR_Size: 33 MB
+Download_slim_TAR_Size: 34 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.4/javadoc
@@ -385,13 +385,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.1.4
 Version: 5.1.3
 Date: 08/01/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.3/hazelcast-5.1.3.zip
-Download_ZIP_Size: 474 MB
+Download_ZIP_Size: 496 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.3/hazelcast-5.1.3-slim.zip
-Download_slim_ZIP_Size: 33 MB
+Download_slim_ZIP_Size: 34 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.3/hazelcast-5.1.3.tar.gz
-Download_TAR_Size: 474 MB
+Download_TAR_Size: 496 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.3/hazelcast-5.1.3-slim.tar.gz
-Download_slim_TAR_Size: 33 MB
+Download_slim_TAR_Size: 34 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.3/javadoc
@@ -403,13 +403,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.1.3
 Version: 5.1.2
 Date: 06/13/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.2/hazelcast-5.1.2.zip
-Download_ZIP_Size: 474 MB
+Download_ZIP_Size: 496 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.2/hazelcast-5.1.2-slim.zip
-Download_slim_ZIP_Size: 33 MB
+Download_slim_ZIP_Size: 34 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.2/hazelcast-5.1.2.tar.gz
-Download_TAR_Size: 474 MB
+Download_TAR_Size: 496 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.2/hazelcast-5.1.2-slim.tar.gz
-Download_slim_TAR_Size: 33 MB
+Download_slim_TAR_Size: 34 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.2/javadoc
@@ -421,13 +421,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.1.2
 Version: 5.1.1
 Date: 03/17/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.1/hazelcast-5.1.1.zip
-Download_ZIP_Size: 479 MB
+Download_ZIP_Size: 502 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.1/hazelcast-5.1.1-slim.zip
-Download_slim_ZIP_Size: 33 MB
+Download_slim_ZIP_Size: 34 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.1/hazelcast-5.1.1.tar.gz
-Download_TAR_Size: 479 MB
+Download_TAR_Size: 502 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1.1/hazelcast-5.1.1-slim.tar.gz
-Download_slim_TAR_Size: 33 MB
+Download_slim_TAR_Size: 34 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1.1/javadoc
@@ -439,13 +439,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.1.1
 Version: 5.1
 Date: 03/01/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1/hazelcast-5.1.zip
-Download_ZIP_Size: 479 MB
+Download_ZIP_Size: 502 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1/hazelcast-5.1-slim.zip
-Download_slim_ZIP_Size: 33 MB
+Download_slim_ZIP_Size: 34 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1/hazelcast-5.1.tar.gz
-Download_TAR_Size: 479 MB
+Download_TAR_Size: 502 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.1/hazelcast-5.1-slim.tar.gz
-Download_slim_TAR_Size: 33 MB
+Download_slim_TAR_Size: 34 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.1/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.1/javadoc
@@ -457,11 +457,11 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.1
 Version: 5.0.5
 Date: 06/28/2023
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.5/hazelcast-5.0.5.zip
-Download_ZIP_Size: 471 MB
+Download_ZIP_Size: 494 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.5/hazelcast-5.0.5-slim.zip
 Download_slim_ZIP_Size: 30 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.5/hazelcast-5.0.5.tar.gz
-Download_TAR_Size: 471 MB
+Download_TAR_Size: 494 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.5/hazelcast-5.0.5-slim.tar.gz
 Download_slim_TAR_Size: 30 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
@@ -475,13 +475,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.0.5
 Version: 5.0.4
 Date: 11/24/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.4/hazelcast-5.0.4.zip
-Download_ZIP_Size: 471 MB
+Download_ZIP_Size: 493 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.4/hazelcast-5.0.4-slim.zip
-Download_slim_ZIP_Size: 29 MB
+Download_slim_ZIP_Size: 30 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.4/hazelcast-5.0.4.tar.gz
-Download_TAR_Size: 471 MB
+Download_TAR_Size: 493 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.4/hazelcast-5.0.4-slim.tar.gz
-Download_slim_TAR_Size: 29 MB
+Download_slim_TAR_Size: 30 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.0.4/javadoc
@@ -493,13 +493,13 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.0.4
 Version: 5.0.3
 Date: 03/28/2022
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.3/hazelcast-5.0.3.zip
-Download_ZIP_Size: 469 MB
+Download_ZIP_Size: 491 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.3/hazelcast-5.0.3-slim.zip
-Download_slim_ZIP_Size: 28 MB
+Download_slim_ZIP_Size: 29 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.3/hazelcast-5.0.3.tar.gz
-Download_TAR_Size: 469 MB
+Download_TAR_Size: 491 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.3/hazelcast-5.0.3-slim.tar.gz
-Download_slim_TAR_Size: 28 MB
+Download_slim_TAR_Size: 29 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
 Docs_PDF:
 APIDocs: https://docs.hazelcast.org/docs/5.0.3/javadoc
@@ -511,11 +511,11 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.0.3
 Version: 5.0.2
 Date: 12/21/2021
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.2/hazelcast-5.0.2.zip
-Download_ZIP_Size: 722 MB
+Download_ZIP_Size: 757 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.2/hazelcast-5.0.2-slim.zip
 Download_slim_ZIP_Size: 28 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.2/hazelcast-5.0.2.tar.gz
-Download_TAR_Size: 722 MB
+Download_TAR_Size: 757 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.2/hazelcast-5.0.2-slim.tar.gz
 Download_slim_TAR_Size: 28 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
@@ -529,11 +529,11 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.0.2
 Version: 5.0.1
 Date: 12/17/2021
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.1/hazelcast-5.0.1.zip
-Download_ZIP_Size: 722 MB
+Download_ZIP_Size: 756 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.1/hazelcast-5.0.1-slim.zip
 Download_slim_ZIP_Size: 28 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.1/hazelcast-5.0.1.tar.gz
-Download_TAR_Size: 722 MB
+Download_TAR_Size: 756 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0.1/hazelcast-5.0.1-slim.tar.gz
 Download_slim_TAR_Size: 28 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html
@@ -547,11 +547,11 @@ Github: https://github.com/hazelcast/hazelcast/tree/v5.0.1
 Version: 5.0
 Date: 09/22/2021
 Download_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0/hazelcast-5.0.zip
-Download_ZIP_Size: 680 MB
+Download_ZIP_Size: 712 MB
 Download_slim_ZIP_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0/hazelcast-5.0-slim.zip
 Download_slim_ZIP_Size: 28 MB
 Download_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0/hazelcast-5.0.tar.gz
-Download_TAR_Size: 680 MB
+Download_TAR_Size: 712 MB
 Download_slim_TAR_URL: https://github.com/hazelcast/hazelcast/releases/download/v5.0/hazelcast-5.0-slim.tar.gz
 Download_slim_TAR_Size: 28 MB
 Docs_HTML: https://docs.hazelcast.com/hazelcast/5.0/getting-started/quickstart.html

--- a/management-center.txt
+++ b/management-center.txt
@@ -37,9 +37,9 @@ Github:
 Version: 5.9.0
 Date: 10/15/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.9.0.zip
-Download_ZIP_Size: 319.1 MB
+Download_ZIP_Size: 311.0 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.9.0.tar.gz
-Download_TAR_Size: 318.8 MB
+Download_TAR_Size: 311.0 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.9/
@@ -69,9 +69,9 @@ Github:
 Version: 5.7.1
 Date: 02/19/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.7.1.zip
-Download_ZIP_Size: 244.57 MB
+Download_ZIP_Size: 256.5 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.7.1.tar.gz
-Download_TAR_Size: 244.57 MB
+Download_TAR_Size: 256.5 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.7/
@@ -85,9 +85,9 @@ Github:
 Version: 5.7.0
 Date: 02/12/2025
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.7.0.zip
-Download_ZIP_Size: 244.6 MB
+Download_ZIP_Size: 256.4 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.7.0.tar.gz
-Download_TAR_Size: 244.6 MB
+Download_TAR_Size: 256.4 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.7/
@@ -101,9 +101,9 @@ Github:
 Version: 5.6.0
 Date: 10/21/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.6.0.zip
-Download_ZIP_Size: 240.9 MB
+Download_ZIP_Size: 252.6 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.6.0.tar.gz
-Download_TAR_Size: 240.9 MB
+Download_TAR_Size: 252.6 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.6/
@@ -117,9 +117,9 @@ Github:
 Version: 5.5.2
 Date: 09/02/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.5.2.zip
-Download_ZIP_Size: 239.9 MB
+Download_ZIP_Size: 251.5 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.5.2.tar.gz
-Download_TAR_Size: 239.9 MB
+Download_TAR_Size: 251.5 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.5/
@@ -133,9 +133,9 @@ Github:
 Version: 5.5.1
 Date: 08/07/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.5.1.zip
-Download_ZIP_Size: 239.9 MB
+Download_ZIP_Size: 251.5 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.5.1.tar.gz
-Download_TAR_Size: 239.9 MB
+Download_TAR_Size: 251.5 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.5/
@@ -149,9 +149,9 @@ Github:
 Version: 5.5.0
 Date: 07/29/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.5.0.zip
-Download_ZIP_Size: 239.9 MB
+Download_ZIP_Size: 251.5 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.5.0.tar.gz
-Download_TAR_Size: 239.9 MB
+Download_TAR_Size: 251.5 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.5/
@@ -165,9 +165,9 @@ Github:
 Version: 5.4.1
 Date: 04/19/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.4.1.zip
-Download_ZIP_Size: 233.1 MB
+Download_ZIP_Size: 244.4 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.4.1.tar.gz
-Download_TAR_Size: 233.1 MB
+Download_TAR_Size: 244.4 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.4/
@@ -181,9 +181,9 @@ Github:
 Version: 5.4.0
 Date: 04/15/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.4.0.zip
-Download_ZIP_Size: 233.0 MB
+Download_ZIP_Size: 244.3 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.4.0.tar.gz
-Download_TAR_Size: 233.0 MB
+Download_TAR_Size: 244.3 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.4/
@@ -197,9 +197,9 @@ Github:
 Version: 5.3.4
 Date: 09/20/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.4.zip
-Download_ZIP_Size: 160.8 MB
+Download_ZIP_Size: 168.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.4.tar.gz
-Download_TAR_Size: 160.8 MB
+Download_TAR_Size: 168.7 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.3/
@@ -213,9 +213,9 @@ Github:
 Version: 5.3.3
 Date: 10/17/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.3.zip
-Download_ZIP_Size: 158.1 MB
+Download_ZIP_Size: 165.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.3.tar.gz
-Download_TAR_Size: 158.1 MB
+Download_TAR_Size: 165.7 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.3/
@@ -229,9 +229,9 @@ Github:
 Version: 5.3.2
 Date: 08/10/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.2.zip
-Download_ZIP_Size: 158.0 MB
+Download_ZIP_Size: 165.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.2.tar.gz
-Download_TAR_Size: 158.0 MB
+Download_TAR_Size: 165.7 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.3/
@@ -245,9 +245,9 @@ Github:
 Version: 5.3.1
 Date: 07/06/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.1.zip
-Download_ZIP_Size: 158.0 MB
+Download_ZIP_Size: 165.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.1.tar.gz
-Download_TAR_Size: 158.0 MB
+Download_TAR_Size: 165.7 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.3/
@@ -261,9 +261,9 @@ Github:
 Version: 5.3.0
 Date: 05/19/2023
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.0.zip
-Download_ZIP_Size: 157.0 MB
+Download_ZIP_Size: 164.6 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.3.0.tar.gz
-Download_TAR_Size: 157.0 MB
+Download_TAR_Size: 164.6 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.3/
@@ -277,9 +277,9 @@ Github:
 Version: 5.2.1
 Date: 12/01/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.2.1.zip
-Download_ZIP_Size: 150.0 MB
+Download_ZIP_Size: 157.3 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.2.1.tar.gz
-Download_TAR_Size: 150.0 MB
+Download_TAR_Size: 157.3 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.2/
@@ -293,9 +293,9 @@ Github:
 Version: 5.2.0
 Date: 10/24/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.2.1.zip
-Download_ZIP_Size: 150.0 MB
+Download_ZIP_Size: 157.3 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.2.1.tar.gz
-Download_TAR_Size: 150.0 MB
+Download_TAR_Size: 157.3 MB
 Download_WAR_URL:
 Download_WAR_Size:
 Docs_HTML: https://docs.hazelcast.com/management-center/5.2/
@@ -309,11 +309,11 @@ Github:
 Version: 5.1.4
 Date: 07/05/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.4.zip
-Download_ZIP_Size: 120.6 MB
+Download_ZIP_Size: 126.5 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.4.tar.gz
-Download_TAR_Size: 120.6 MB
+Download_TAR_Size: 126.5 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.4.war
-Download_WAR_Size: 135.0 MB
+Download_WAR_Size: 141.6 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/5.1/
 Docs_PDF:
 APIDocs:
@@ -325,11 +325,11 @@ Github:
 Version: 5.1.3
 Date: 04/22/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.3.zip
-Download_ZIP_Size: 120.5 MB
+Download_ZIP_Size: 126.4 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.3.tar.gz
-Download_TAR_Size: 120.5 MB
+Download_TAR_Size: 126.4 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.3.war
-Download_WAR_Size: 135.0 MB
+Download_WAR_Size: 141.6 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/5.1/
 Docs_PDF:
 APIDocs:
@@ -341,11 +341,11 @@ Github:
 Version: 5.1.2
 Date: 04/06/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.2.zip
-Download_ZIP_Size: 120.5 MB
+Download_ZIP_Size: 126.4 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.2.tar.gz
-Download_TAR_Size: 120.5 MB
+Download_TAR_Size: 126.4 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.2.war
-Download_WAR_Size: 135.0 MB
+Download_WAR_Size: 141.5 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/5.1/
 Docs_PDF:
 APIDocs:
@@ -357,11 +357,11 @@ Github:
 Version: 5.1.1
 Date: 03/01/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.1.zip
-Download_ZIP_Size: 120.5 MB
+Download_ZIP_Size: 126.4 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.1.tar.gz
-Download_TAR_Size: 120.5 MB
+Download_TAR_Size: 126.4 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.1.1.war
-Download_WAR_Size: 135.0 MB
+Download_WAR_Size: 141.5 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/5.1/
 Docs_PDF:
 APIDocs:
@@ -373,11 +373,11 @@ Github:
 Version: 5.0.4
 Date: 12/20/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.0.4.zip
-Download_ZIP_Size: 117.9 MB
+Download_ZIP_Size: 123.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.0.4.tar.gz
-Download_TAR_Size: 117.9 MB
+Download_TAR_Size: 123.7 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.0.4.war
-Download_WAR_Size: 133.2 MB
+Download_WAR_Size: 139.7 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/5.0/
 Docs_PDF:
 APIDocs:
@@ -389,11 +389,11 @@ Github:
 Version: 5.0.3
 Date: 12/14/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.0.3.zip
-Download_ZIP_Size: 117.9 MB
+Download_ZIP_Size: 123.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.0.3.tar.gz
-Download_TAR_Size: 117.9 MB
+Download_TAR_Size: 123.7 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.0.3.war
-Download_WAR_Size: 133.2 MB
+Download_WAR_Size: 139.7 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/5.0/
 Docs_PDF:
 APIDocs:
@@ -453,11 +453,11 @@ Github:
 Version: 4.2022.01
 Date: 01/06/2022
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2022.01.zip
-Download_ZIP_Size: 116.0 MB
+Download_ZIP_Size: 121.6 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2022.01.tar.gz
-Download_TAR_Size: 116.1 MB
+Download_TAR_Size: 121.7 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2022.01.war
-Download_WAR_Size: 137.1 MB
+Download_WAR_Size: 143.7 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/4.2022.01/
 Docs_PDF:
 APIDocs:
@@ -469,11 +469,11 @@ Github:
 Version: 4.2021.12-1
 Date: 12/20/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.12-1.zip
-Download_ZIP_Size: 116.0 MB
+Download_ZIP_Size: 121.6 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.12-1.tar.gz
-Download_TAR_Size: 116.1 MB
+Download_TAR_Size: 121.7 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.12-1.war
-Download_WAR_Size: 137.1 MB
+Download_WAR_Size: 143.7 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/4.2021.12-1/
 Docs_PDF:
 APIDocs:
@@ -501,11 +501,11 @@ Github:
 Version: 4.2021.06
 Date: 06/21/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.06.zip
-Download_ZIP_Size: 115.9 MB
+Download_ZIP_Size: 121.5 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.06.tar.gz
-Download_TAR_Size: 116 MB
+Download_TAR_Size: 121.6 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.06.war
-Download_WAR_Size: 137 MB
+Download_WAR_Size: 143.7 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/4.2021.06/
 Docs_PDF:
 APIDocs:
@@ -521,7 +521,7 @@ Download_ZIP_Size: 115.2 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.04.tar.gz
 Download_TAR_Size: 115.3 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.04.war
-Download_WAR_Size: 132.7 MB
+Download_WAR_Size: 132.8 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/4.2021.04/
 Docs_PDF:
 APIDocs:
@@ -549,7 +549,7 @@ Github:
 Version: 4.2021.02
 Date: 02/12/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.02.zip
-Download_ZIP_Size: 113.8 MB
+Download_ZIP_Size: 113.9 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.02.tar.gz
 Download_TAR_Size: 113.9 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.02.war
@@ -567,7 +567,7 @@ Date: 12/11/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2020.12.zip
 Download_ZIP_Size: 103.8 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2020.12.tar.gz
-Download_TAR_Size: 103.8 MB
+Download_TAR_Size: 103.9 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2020.12.war
 Download_WAR_Size: 103.2 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/4.2020.12/manual/html/index.html
@@ -581,11 +581,11 @@ Github:
 Version: 4.2020.10
 Date: 10/29/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2020.10.zip
-Download_ZIP_Size: 100.5 MB
+Download_ZIP_Size: 100.6 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2020.10.tar.gz
 Download_TAR_Size: 100.6 MB
 Download_WAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2020.10.war
-Download_WAR_Size: 99.4 MB
+Download_WAR_Size: 99.5 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/4.2020.10/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/4.2020.10/manual/pdf/hazelcast-management-center-documentation-4.2020.10.pdf
 APIDocs:
@@ -597,7 +597,7 @@ Github:
 Version: 4.2020.08
 Date: 08/11/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2020.08.zip
-Download_ZIP_Size: 82.7 MB
+Download_ZIP_Size: 82.8 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2020.08.tar.gz
 Download_TAR_Size: 82.8 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/4.2020.08/manual/html/index.html
@@ -625,9 +625,9 @@ Github:
 Version: 4.0.2
 Date: 04/29/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.0.2.zip
-Download_ZIP_Size: 88 MB
+Download_ZIP_Size: 87.8 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.0.2.tar.gz
-Download_TAR_Size: 88 MB
+Download_TAR_Size: 87.8 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/4.0.2/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/4.0.2/manual/pdf/hazelcast-management-center-documentation-4.0.2.pdf
 APIDocs:
@@ -639,9 +639,9 @@ Github:
 Version: 4.0.1
 Date: 03/09/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.0.1.zip
-Download_ZIP_Size: 90 MB
+Download_ZIP_Size: 90.0 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.0.1.tar.gz
-Download_TAR_Size: 90 MB
+Download_TAR_Size: 90.0 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/4.0.1/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/4.0.1/manual/pdf/hazelcast-management-center-documentation-4.0.1.pdf
 APIDocs:
@@ -653,9 +653,9 @@ Github:
 Version: 4.0
 Date: 02/04/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.0.zip
-Download_ZIP_Size: 108 MB
+Download_ZIP_Size: 113.4 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.0.tar.gz
-Download_TAR_Size: 108 MB
+Download_TAR_Size: 113.5 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/4.0/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/4.0/manual/pdf/hazelcast-management-center-documentation-4.0.pdf
 APIDocs:
@@ -681,9 +681,9 @@ Github:
 Version: 3.12.17
 Date: 06/28/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.17.zip
-Download_ZIP_Size: 88.4 MB
+Download_ZIP_Size: 91.3 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.17.tar.gz
-Download_TAR_Size: 88.4 MB
+Download_TAR_Size: 91.4 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.17/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.17/manual/pdf/hazelcast-management-center-documentation-3.12.17.pdf
 APIDocs:
@@ -697,7 +697,7 @@ Date: 05/08/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.16.zip
 Download_ZIP_Size: 88.4 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.16.tar.gz
-Download_TAR_Size: 88.4 MB
+Download_TAR_Size: 88.5 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.16/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.16/manual/pdf/hazelcast-management-center-documentation-3.12.16.pdf
 APIDocs:
@@ -711,7 +711,7 @@ Date: 03/11/2021
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.15.zip
 Download_ZIP_Size: 88.1 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.15.tar.gz
-Download_TAR_Size: 88.1 MB
+Download_TAR_Size: 88.2 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.15/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.15/manual/pdf/hazelcast-management-center-documentation-3.12.15.pdf
 APIDocs:
@@ -737,9 +737,9 @@ Github:
 Version: 3.12.13
 Date: 11/13/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.13.zip
-Download_ZIP_Size: 89.2 MB
+Download_ZIP_Size: 89.3 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.13.tar.gz
-Download_TAR_Size: 89.2 MB
+Download_TAR_Size: 89.3 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.13/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.13/manual/pdf/hazelcast-management-center-documentation-3.12.13.pdf
 APIDocs:
@@ -779,9 +779,9 @@ Github:
 Version: 3.12.10
 Date: 06/05/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.10.zip
-Download_ZIP_Size: 60.3 MB
+Download_ZIP_Size: 60.4 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.10.tar.gz
-Download_TAR_Size: 60.3 MB
+Download_TAR_Size: 60.4 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.10/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.10/manual/pdf/hazelcast-management-center-documentation-3.12.10.pdf
 APIDocs:
@@ -793,9 +793,9 @@ Github:
 Version: 3.12.9
 Date: 03/17/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.9.zip
-Download_ZIP_Size: 61 MB
+Download_ZIP_Size: 60.2 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.9.tar.gz
-Download_TAR_Size: 61 MB
+Download_TAR_Size: 60.2 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.9/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.9/manual/pdf/hazelcast-management-center-documentation-3.12.9.pdf
 APIDocs:
@@ -807,9 +807,9 @@ Github:
 Version: 3.12.8
 Date: 12/19/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.8.zip
-Download_ZIP_Size: 57 MB
+Download_ZIP_Size: 60.1 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.8.tar.gz
-Download_TAR_Size: 57 MB
+Download_TAR_Size: 60.1 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.8/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.8/manual/pdf/hazelcast-management-center-documentation-3.12.8.pdf
 APIDocs:
@@ -821,9 +821,9 @@ Github:
 Version: 3.12.7
 Date: 11/11/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.7.zip
-Download_ZIP_Size: 57.1 MB
+Download_ZIP_Size: 60.0 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.7.tar.gz
-Download_TAR_Size: 57.1 MB
+Download_TAR_Size: 60.0 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.7/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.7/manual/pdf/hazelcast-management-center-documentation-3.12.7.pdf
 APIDocs:
@@ -835,9 +835,9 @@ Github:
 Version: 3.12.6
 Date: 10/10/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.6.zip
-Download_ZIP_Size: 57.1 MB
+Download_ZIP_Size: 59.9 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.6.tar.gz
-Download_TAR_Size: 57.1 MB
+Download_TAR_Size: 59.9 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.6/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.6/manual/pdf/hazelcast-management-center-documentation-3.12.6.pdf
 APIDocs:
@@ -849,9 +849,9 @@ Github:
 Version: 3.12.5
 Date: 09/02/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.5.zip
-Download_ZIP_Size: 56.9 MB
+Download_ZIP_Size: 59.6 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.5.tar.gz
-Download_TAR_Size: 56.8 MB
+Download_TAR_Size: 59.6 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.5/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.5/manual/pdf/hazelcast-management-center-documentation-3.12.5.pdf
 APIDocs:
@@ -863,9 +863,9 @@ Github:
 Version: 3.12.4
 Date: 08/13/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.4.zip
-Download_ZIP_Size: 56.4 MB
+Download_ZIP_Size: 59.1 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.4.tar.gz
-Download_TAR_Size: 56.3 MB
+Download_TAR_Size: 59.1 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.4/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.4/manual/pdf/hazelcast-management-center-documentation-3.12.4.pdf
 APIDocs:
@@ -877,9 +877,9 @@ Github:
 Version: 3.12.3
 Date: 07/30/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.3.zip
-Download_ZIP_Size: 57.1 MB
+Download_ZIP_Size: 59.1 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.3.tar.gz
-Download_TAR_Size: 57.1 MB
+Download_TAR_Size: 59.1 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.3/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.3/manual/pdf/hazelcast-management-center-documentation-3.12.3.pdf
 APIDocs: 
@@ -891,9 +891,9 @@ Github:
 Version: 3.12.2
 Date: 07/18/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.2.zip
-Download_ZIP_Size: 57.1 MB
+Download_ZIP_Size: 59.9 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.2.tar.gz
-Download_TAR_Size: 57.1 MB
+Download_TAR_Size: 59.8 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12.2/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12.2/manual/pdf/hazelcast-management-center-documentation-3.12.2.pdf
 APIDocs: 
@@ -919,9 +919,9 @@ Github:
 Version: 3.12
 Date: 04/09/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.zip
-Download_ZIP_Size: 57 MB
+Download_ZIP_Size: 59.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.12.tar.gz
-Download_TAR_Size: 57 MB
+Download_TAR_Size: 59.7 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.12/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.12/manual/pdf/hazelcast-management-center-documentation-3.12.pdf
 APIDocs: 
@@ -933,9 +933,9 @@ Github:
 Version: 3.11.4
 Date: 10/01/2020
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.11.4.zip
-Download_ZIP_Size: 52.9 MB
+Download_ZIP_Size: 55.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.11.4.tar.gz
-Download_TAR_Size: 52.9 MB
+Download_TAR_Size: 55.7 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.11.4/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.11.4/manual/pdf/hazelcast-management-center-documentation-3.11.4.pdf
 APIDocs: 
@@ -947,9 +947,9 @@ Github:
 Version: 3.11.3
 Date: 01/31/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.11.3.zip
-Download_ZIP_Size: 52.9 MB
+Download_ZIP_Size: 55.5 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.11.3.tar.gz
-Download_TAR_Size: 52.9 MB
+Download_TAR_Size: 55.5 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.11.3/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.11.3/manual/pdf/hazelcast-management-center-documentation-3.11.3.pdf
 APIDocs: 
@@ -989,9 +989,9 @@ Github:
 Version: 3.11
 Date: 10/23/2018
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.11.zip
-Download_ZIP_Size: 43.4 MB
+Download_ZIP_Size: 45.5 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.11.tar.gz
-Download_TAR_Size: 43.4 MB
+Download_TAR_Size: 45.5 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.11/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.11/manual/pdf/hazelcast-management-center-documentation-3.11.pdf
 APIDocs: 
@@ -1003,9 +1003,9 @@ Github:
 Version: 3.10.4
 Date: 09/18/2019
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.4.zip
-Download_ZIP_Size: 41.2 MB
+Download_ZIP_Size: 43.3 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.4.tar.gz
-Download_TAR_Size: 41.2 MB
+Download_TAR_Size: 43.3 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.10.4/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.10.4/manual/pdf/hazelcast-management-center-documentation-3.10.4.pdf
 APIDocs:
@@ -1017,9 +1017,9 @@ Github:
 Version: 3.10.3
 Date: 09/07/2018
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.3.zip
-Download_ZIP_Size: 41.2 MB
+Download_ZIP_Size: 43.2 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.3.tar.gz
-Download_TAR_Size: 41.2 MB
+Download_TAR_Size: 43.2 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.10.3/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.10.3/manual/pdf/hazelcast-management-center-documentation-3.10.3.pdf
 APIDocs:
@@ -1031,9 +1031,9 @@ Github:
 Version: 3.10.2
 Date: 07/02/2018
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.2.zip
-Download_ZIP_Size: 40.4 MB
+Download_ZIP_Size: 42.3 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.2.tar.gz
-Download_TAR_Size: 40.4 MB
+Download_TAR_Size: 42.3 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.10.2/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.10.2/manual/pdf/hazelcast-management-center-documentation-3.10.2.pdf
 APIDocs:
@@ -1045,9 +1045,9 @@ Github:
 Version: 3.10.1
 Date: 05/28/2018
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.1.zip
-Download_ZIP_Size: 39 MB
+Download_ZIP_Size: 39.9 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.1.tar.gz
-Download_TAR_Size: 39 MB
+Download_TAR_Size: 39.9 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.10.1/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.10.1/manual/pdf/hazelcast-management-center-documentation-3.10.1.pdf
 APIDocs: 
@@ -1059,9 +1059,9 @@ Github:
 Version: 3.10
 Date: 05/03/2018
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.zip
-Download_ZIP_Size: 26.5 MB
+Download_ZIP_Size: 27.8 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-3.10.tar.gz
-Download_TAR_Size: 26.5 MB
+Download_TAR_Size: 27.7 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.10/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.10/manual/pdf/hazelcast-management-center-documentation-3.10.pdf
 APIDocs:
@@ -1073,7 +1073,7 @@ Github:
 Version: 3.9.4
 Date: 04/09/2018
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/management-center-3.9.4.zip
-Download_ZIP_Size: 20.8 MB
+Download_ZIP_Size: 21.0 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/management-center-3.9.4.tar.gz
 Download_TAR_Size: 20.8 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.9.4/manual/html/index.html
@@ -1087,7 +1087,7 @@ Github:
 Version: 3.9.3
 Date: 03/22/2018
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/management-center-3.9.3.zip
-Download_ZIP_Size: 20.8 MB
+Download_ZIP_Size: 21.0 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/management-center-3.9.3.tar.gz
 Download_TAR_Size: 20.8 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.9.3/manual/html/index.html
@@ -1115,9 +1115,9 @@ Github:
 Version: 3.9.1
 Date: 11/29/2017
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/management-center-3.9.1.zip
-Download_ZIP_Size: 24 MB
+Download_ZIP_Size: 24.8 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/management-center-3.9.1.tar.gz
-Download_TAR_Size: 24 MB
+Download_TAR_Size: 24.6 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.9.1/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.9.1/manual/pdf/management-center-documentation-3.9.1.pdf
 APIDocs: 
@@ -1129,9 +1129,9 @@ Github:
 Version: 3.9
 Date: 10/27/2017
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/management-center-3.9.zip
-Download_ZIP_Size: 24 MB
+Download_ZIP_Size: 24.7 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/management-center-3.9.tar.gz
-Download_TAR_Size: 24 MB
+Download_TAR_Size: 24.6 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.9/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.9/manual/pdf/management-center-documentation-3.9.pdf
 APIDocs: 
@@ -1143,9 +1143,9 @@ Github:
 Version: 3.8.5
 Date: 10/27/2017
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/management-center-3.8.5.zip
-Download_ZIP_Size: 22.0 MB
+Download_ZIP_Size: 23.1 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/management-center-3.8.5.tar.gz
-Download_TAR_Size: 21.9 MB
+Download_TAR_Size: 22.9 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.8.5/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.8.5/manual/pdf/management-center-documentation-3.8.5.pdf
 APIDocs:
@@ -1157,9 +1157,9 @@ Github:
 Version: 3.8.4
 Date: 08/16/2017
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/management-center-3.8.4.zip
-Download_ZIP_Size: 22.7 MB
+Download_ZIP_Size: 23.3 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/management-center-3.8.4.tar.gz
-Download_TAR_Size: 22.6 MB
+Download_TAR_Size: 23.2 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.8.4/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.8.4/manual/pdf/management-center-documentation-3.8.4.pdf
 APIDocs:
@@ -1171,9 +1171,9 @@ Github:
 Version: 3.8.3
 Date: 06/21/2017
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/management-center-3.8.3.zip
-Download_ZIP_Size: 22.7 MB
+Download_ZIP_Size: 23.2 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/management-center-3.8.3.tar.gz
-Download_TAR_Size: 22.6 MB
+Download_TAR_Size: 23.1 MB
 Docs_HTML: http://docs.hazelcast.org/docs/management-center/3.8.3/manual/html/index.html
 Docs_PDF: http://docs.hazelcast.org/docs/management-center/3.8.3/manual/pdf/management-center-documentation-3.8.3.pdf
 APIDocs: 
@@ -1187,9 +1187,9 @@ Github:
 Version: 5.4.0-BETA-2
 Date: 02/13/2024
 Download_ZIP_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.4.0-BETA-2.zip
-Download_ZIP_Size: 227.8 MB
+Download_ZIP_Size: 238.9 MB
 Download_TAR_URL: https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.4.0-BETA-2.tar.gz
-Download_TAR_Size: 227.8 MB
+Download_TAR_Size: 238.9 MB
 Docs_HTML: https://docs.hazelcast.com/management-center/5.4.0-BETA-2/
 Docs_PDF: 
 APIDocs: 


### PR DESCRIPTION
In https://github.com/hazelcast/rel-scripts/pull/56, it was discovered the pipeline was using wrong filesizes (`MiB` vs `MB`).

Although that updated _future_ files, that left older files stuck.

I've gone through and updated to be consistent, based on logic _like_:
```
curl -sI https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.11.0.zip | awk '/^[Cc]ontent-[Ll]ength:/ {print $2}' | tr -d '\r'

printf '%s\n' 326254801 | awk '{ printf "%.1f MB\n", $1 / 1000000 }'
```

For platform, I've used whole-sizes, for MC, 1 decimal place to be consistent with existing format.
I've left the rest as parsing disparate formats is too complex for a throwaway activity.