### PR TITLE
Update `rel-scripts` to use pre-prod artifacts for file-size calculations [DI-794]

### DIFF
--- a/.github/python/add-release/add_release.py
+++ b/.github/python/add-release/add_release.py
@@ -19,12 +19,16 @@ def main() -> None:
     parser.add_argument("--version", required=True)
     parser.add_argument("--github-org", required=True)
     parser.add_argument("--ee-release-repo-name", required=True)
+    parser.add_argument("--jfrog-preprod-files-repo", required=True)
     parser.add_argument("--should-build-oss", required=True)
     parser.add_argument("--should-build-ee", required=True)
     args = parser.parse_args()
 
     version_metadata = VersionMetadata(
-        args.version, args.github_org, args.ee_release_repo_name
+        args.version,
+        args.github_org,
+        args.ee_release_repo_name,
+        args.jfrog_preprod_files_repo,
     )
     logging.debug("version=%s", version_metadata.version)
 
@@ -46,13 +50,13 @@ def update_hazelcast_open_source_metadata(version_metadata: VersionMetadata):
     version_block = f"""---
 Version: {version_metadata.version}
 Date: ${{TBC_RELEASE_DATE}}
-Download_ZIP_URL: {version_metadata.os_downloads.full_zip.url}
+Download_ZIP_URL: {version_metadata.os_downloads.full_zip.live_url}
 Download_ZIP_Size: {version_metadata.os_downloads.full_zip.size}
-Download_slim_ZIP_URL: {version_metadata.os_downloads.slim_zip.url}
+Download_slim_ZIP_URL: {version_metadata.os_downloads.slim_zip.live_url}
 Download_slim_ZIP_Size: {version_metadata.os_downloads.slim_zip.size}
-Download_TAR_URL: {version_metadata.os_downloads.full_tar.url}
+Download_TAR_URL: {version_metadata.os_downloads.full_tar.live_url}
 Download_TAR_Size: {version_metadata.os_downloads.full_tar.size}
-Download_slim_TAR_URL: {version_metadata.os_downloads.slim_tar.url}
+Download_slim_TAR_URL: {version_metadata.os_downloads.slim_tar.live_url}
 Download_slim_TAR_Size: {version_metadata.os_downloads.slim_tar.size}
 Docs_HTML: {version_metadata.docs_url}
 Docs_PDF:
@@ -75,13 +79,13 @@ def update_hazelcast_enterprise_metadata(version_metadata: VersionMetadata):
     version_block = f"""---
 Version: {version_metadata.version}
 Date: ${{TBC_RELEASE_DATE}}
-Download_ZIP_URL: {version_metadata.ee_downloads.full_zip.url}
+Download_ZIP_URL: {version_metadata.ee_downloads.full_zip.live_url}
 Download_ZIP_Size: {version_metadata.ee_downloads.full_zip.size}
-Download_slim_ZIP_URL: {version_metadata.ee_downloads.slim_zip.url}
+Download_slim_ZIP_URL: {version_metadata.ee_downloads.slim_zip.live_url}
 Download_slim_ZIP_Size: {version_metadata.ee_downloads.slim_zip.size}
-Download_TAR_URL: {version_metadata.ee_downloads.full_tar.url}
+Download_TAR_URL: {version_metadata.ee_downloads.full_tar.live_url}
 Download_TAR_Size: {version_metadata.ee_downloads.full_tar.size}
-Download_slim_TAR_URL: {version_metadata.ee_downloads.slim_tar.url}
+Download_slim_TAR_URL: {version_metadata.ee_downloads.slim_tar.live_url}
 Download_slim_TAR_Size: {version_metadata.ee_downloads.slim_tar.size}
 Docs_HTML: {version_metadata.docs_url}
 Docs_PDF:
@@ -154,7 +158,7 @@ def update_imdg_clients_metadata(version_metadata: VersionMetadata):
     version_block = f"""---
 Version: {version_metadata.version}
 Date: ${{TBC_RELEASE_DATE}}
-Download: {version_metadata.os_downloads.slim_zip.url}
+Download: {version_metadata.os_downloads.slim_zip.live_url}
 Download_Size: {version_metadata.os_downloads.slim_zip.size}
 Github: {version_metadata.sources_url}
 Docs: {version_metadata.docs_url}

--- a/.github/python/add-release/add_release.py
+++ b/.github/python/add-release/add_release.py
@@ -50,13 +50,13 @@ def update_hazelcast_open_source_metadata(version_metadata: VersionMetadata):
     version_block = f"""---
 Version: {version_metadata.version}
 Date: ${{TBC_RELEASE_DATE}}
-Download_ZIP_URL: {version_metadata.os_downloads.full_zip.live_url}
+Download_ZIP_URL: {version_metadata.os_downloads.full_zip.public_url}
 Download_ZIP_Size: {version_metadata.os_downloads.full_zip.size}
-Download_slim_ZIP_URL: {version_metadata.os_downloads.slim_zip.live_url}
+Download_slim_ZIP_URL: {version_metadata.os_downloads.slim_zip.public_url}
 Download_slim_ZIP_Size: {version_metadata.os_downloads.slim_zip.size}
-Download_TAR_URL: {version_metadata.os_downloads.full_tar.live_url}
+Download_TAR_URL: {version_metadata.os_downloads.full_tar.public_url}
 Download_TAR_Size: {version_metadata.os_downloads.full_tar.size}
-Download_slim_TAR_URL: {version_metadata.os_downloads.slim_tar.live_url}
+Download_slim_TAR_URL: {version_metadata.os_downloads.slim_tar.public_url}
 Download_slim_TAR_Size: {version_metadata.os_downloads.slim_tar.size}
 Docs_HTML: {version_metadata.docs_url}
 Docs_PDF:
@@ -79,13 +79,13 @@ def update_hazelcast_enterprise_metadata(version_metadata: VersionMetadata):
     version_block = f"""---
 Version: {version_metadata.version}
 Date: ${{TBC_RELEASE_DATE}}
-Download_ZIP_URL: {version_metadata.ee_downloads.full_zip.live_url}
+Download_ZIP_URL: {version_metadata.ee_downloads.full_zip.public_url}
 Download_ZIP_Size: {version_metadata.ee_downloads.full_zip.size}
-Download_slim_ZIP_URL: {version_metadata.ee_downloads.slim_zip.live_url}
+Download_slim_ZIP_URL: {version_metadata.ee_downloads.slim_zip.public_url}
 Download_slim_ZIP_Size: {version_metadata.ee_downloads.slim_zip.size}
-Download_TAR_URL: {version_metadata.ee_downloads.full_tar.live_url}
+Download_TAR_URL: {version_metadata.ee_downloads.full_tar.public_url}
 Download_TAR_Size: {version_metadata.ee_downloads.full_tar.size}
-Download_slim_TAR_URL: {version_metadata.ee_downloads.slim_tar.live_url}
+Download_slim_TAR_URL: {version_metadata.ee_downloads.slim_tar.public_url}
 Download_slim_TAR_Size: {version_metadata.ee_downloads.slim_tar.size}
 Docs_HTML: {version_metadata.docs_url}
 Docs_PDF:
@@ -158,7 +158,7 @@ def update_imdg_clients_metadata(version_metadata: VersionMetadata):
     version_block = f"""---
 Version: {version_metadata.version}
 Date: ${{TBC_RELEASE_DATE}}
-Download: {version_metadata.os_downloads.slim_zip.live_url}
+Download: {version_metadata.os_downloads.slim_zip.public_url}
 Download_Size: {version_metadata.os_downloads.slim_zip.size}
 Github: {version_metadata.sources_url}
 Docs: {version_metadata.docs_url}

--- a/.github/python/add-release/tests/test_version_metadata.py
+++ b/.github/python/add-release/tests/test_version_metadata.py
@@ -16,10 +16,10 @@ def test_build_downloads():
         "https://example.com/foo", "https://example.com/bar"
     )
 
-    assert downloads.full_zip.live_url == "https://example.com/foo.zip"
-    assert downloads.slim_zip.live_url == "https://example.com/foo-slim.zip"
-    assert downloads.full_tar.live_url == "https://example.com/foo.tar.gz"
-    assert downloads.slim_tar.live_url == "https://example.com/foo-slim.tar.gz"
+    assert downloads.full_zip.public_url == "https://example.com/foo.zip"
+    assert downloads.slim_zip.public_url == "https://example.com/foo-slim.zip"
+    assert downloads.full_tar.public_url == "https://example.com/foo.tar.gz"
+    assert downloads.slim_tar.public_url == "https://example.com/foo-slim.tar.gz"
 
 
 def test_download_size():
@@ -27,7 +27,7 @@ def test_download_size():
     slim_zip = version_metadata.os_downloads.slim_zip
 
     assert (
-        slim_zip.live_url
+        slim_zip.public_url
         == "https://github.com/hazelcast/hazelcast/releases/download/v5.6.0/hazelcast-5.6.0-slim.zip"
     )
     assert slim_zip.size == "41 MB"

--- a/.github/python/add-release/tests/test_version_metadata.py
+++ b/.github/python/add-release/tests/test_version_metadata.py
@@ -11,21 +11,23 @@ vm = pytest.importorskip("version_metadata")
 
 
 def test_build_downloads():
-    version_metadata = vm.VersionMetadata("5.4.1", "hazelcast", "download")
-    downloads = version_metadata._build_downloads("https://example.com/foo")
+    version_metadata = vm.VersionMetadata("5.4.1", "hazelcast", "download", "preprod")
+    downloads = version_metadata._build_downloads(
+        "https://example.com/foo", "https://example.com/bar"
+    )
 
-    assert downloads.full_zip.url == "https://example.com/foo.zip"
-    assert downloads.slim_zip.url == "https://example.com/foo-slim.zip"
-    assert downloads.full_tar.url == "https://example.com/foo.tar.gz"
-    assert downloads.slim_tar.url == "https://example.com/foo-slim.tar.gz"
+    assert downloads.full_zip.live_url == "https://example.com/foo.zip"
+    assert downloads.slim_zip.live_url == "https://example.com/foo-slim.zip"
+    assert downloads.full_tar.live_url == "https://example.com/foo.tar.gz"
+    assert downloads.slim_tar.live_url == "https://example.com/foo-slim.tar.gz"
 
 
 def test_download_size():
-    version_metadata = vm.VersionMetadata("5.6.0", "hazelcast", "download")
+    version_metadata = vm.VersionMetadata("5.6.0", "hazelcast", "download", "preprod")
     slim_zip = version_metadata.os_downloads.slim_zip
 
     assert (
-        slim_zip.url
+        slim_zip.live_url
         == "https://github.com/hazelcast/hazelcast/releases/download/v5.6.0/hazelcast-5.6.0-slim.zip"
     )
     assert slim_zip.size == "41 MB"

--- a/.github/python/add-release/version_metadata.py
+++ b/.github/python/add-release/version_metadata.py
@@ -56,12 +56,12 @@ class DownloadUrl:
             try:
                 self._size = self._get_size(self.preprod_url)
             except requests.RequestException:
-                self._size = self._get_size(self.live_url)
+                self._size = self._get_size(self.public_url)
 
         return self._size
 
     @property
-    def live_url(self) -> str:
+    def public_url(self) -> str:
         return f"{self._live_base_url}{self._suffix}"
 
     @property

--- a/.github/python/add-release/version_metadata.py
+++ b/.github/python/add-release/version_metadata.py
@@ -6,43 +6,67 @@ import requests
 import semver
 from humanize import naturalsize
 from requests.auth import HTTPBasicAuth
+from urllib.parse import urlparse
 
 
 @dataclass
 class DownloadUrl:
     """A download URL with lazily computed, human-friendly size."""
 
-    url: str
+    _live_base_url: str
+    _preprod_base_url: str
+    _suffix: str
     _size: str = field(default=None, init=False)
 
-    @property
-    def size(self) -> str:
+    @staticmethod
+    def _get_size(url: str) -> str:
         """Fetch and cache the artifact size without _actually_ downloading it."""
         # Lazily evaluates
         # So in the case of (say) an EE-only release we don't query (non-existent) OS artifacts
+        logging.debug("Getting size of %s", url)
+
+        username = os.getenv("RELEASE_REPO_USER")
+        password = os.getenv("RELEASE_REPO_TOKEN")
+
+        auth = (
+            HTTPBasicAuth(username, password)
+            if urlparse(url).hostname == "repository.hazelcast.com"
+            and username
+            and password
+            else None
+        )
+
+        response = requests.head(
+            url,
+            allow_redirects=True,
+            auth=auth,
+        )
+        response.raise_for_status()
+
+        content_length = response.headers["Content-Length"]
+
+        if content_length:
+            return naturalsize(int(content_length), format="%.0f")
+        else:
+            raise Exception(f"{url} did not return a size")
+
+    @property
+    def size(self) -> str:
         if self._size is None:
-            logging.debug("Getting size of %s", self.url)
-
-            username = os.getenv("RELEASE_REPO_USER")
-            password = os.getenv("RELEASE_REPO_TOKEN")
-
-            auth = HTTPBasicAuth(username, password) if username and password else None
-
-            response = requests.head(
-                self.url,
-                allow_redirects=True,
-                auth=auth,
-            )
-            response.raise_for_status()
-
-            content_length = response.headers["Content-Length"]
-
-            if content_length:
-                self._size = naturalsize(int(content_length), format="%.0f")
-            else:
-                raise Exception(f"{self.url} did not return a size")
+            try:
+                self._size = self._get_size(self.preprod_url)
+            except requests.RequestException:
+                self._size = self._get_size(self.live_url)
 
         return self._size
+
+    @property
+    def live_url(self) -> str:
+        return f"{self._live_base_url}{self._suffix}"
+
+    @property
+    def preprod_url(self) -> str:
+        return f"{self._preprod_base_url}{self._suffix}"
 
 
 @dataclass
@@ -62,17 +86,20 @@ class VersionMetadata:
     version: semver.Version | str
     github_org: InitVar[str]
     ee_release_repo_name: InitVar[str]
+    jfrog_preprod_files_repo: InitVar[str]
 
-    def __post_init__(self, github_org, ee_release_repo_name):
+    def __post_init__(self, github_org, ee_release_repo_name, jfrog_preprod_files_repo):
         """Normalize version and populate derived URLs and metadata."""
         if isinstance(self.version, str):
             self.version = semver.Version.parse(self.version)
 
         self.os_downloads = self._build_downloads(
-            f"https://github.com/{github_org}/hazelcast/releases/download/v{self.version}/hazelcast-{self.version}"
+            f"https://github.com/{github_org}/hazelcast/releases/download/v{self.version}/hazelcast-{self.version}",
+            f"https://repository.hazelcast.com/{jfrog_preprod_files_repo}/hazelcast/hazelcast-{self.version}",
         )
         self.ee_downloads = self._build_downloads(
-            f"https://repository.hazelcast.com/{ee_release_repo_name}/hazelcast-enterprise/hazelcast-enterprise-{self.version}"
+            f"https://repository.hazelcast.com/{ee_release_repo_name}/hazelcast-enterprise/hazelcast-enterprise-{self.version}",
+            f"https://repository.hazelcast.com/{jfrog_preprod_files_repo}/hazelcast-enterprise/hazelcast-enterprise-{self.version}",
         )
 
         self.sources_url = (
@@ -90,11 +117,11 @@ class VersionMetadata:
             f"https://docs.hazelcast.org/hazelcast-ee-docs/{self.version}/javadoc"
         )
 
-    def _build_downloads(self, base: str) -> Downloads:
-        """Build a Downloads object for a given artifact base URL."""
+    def _build_downloads(self, live_base_url: str, preprod_base_url: str) -> Downloads:
+        """Build a Downloads object for a given artifact base live URL."""
         return Downloads(
-            full_zip=DownloadUrl(f"{base}.zip"),
-            slim_zip=DownloadUrl(f"{base}-slim.zip"),
-            full_tar=DownloadUrl(f"{base}.tar.gz"),
-            slim_tar=DownloadUrl(f"{base}-slim.tar.gz"),
+            full_zip=DownloadUrl(live_base_url, preprod_base_url, ".zip"),
+            slim_zip=DownloadUrl(live_base_url, preprod_base_url, "-slim.zip"),
+            full_tar=DownloadUrl(live_base_url, preprod_base_url, ".tar.gz"),
+            slim_tar=DownloadUrl(live_base_url, preprod_base_url, "-slim.tar.gz"),
         )

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -70,6 +70,7 @@ jobs:
             --version=${VERSION} \
             --github-org=${GITHUB_REPOSITORY_OWNER} \
             --ee-release-repo-name=${{ vars.EE_RELEASE_REPO_NAME }} \
+            --jfrog-preprod-files-repo=${{ vars.JFROG_PREPROD_FILES_REPO }} \
             --should-build-oss=${{ steps.resolve-editions.outputs.should_build_oss }} \
             --should-build-ee=${{ steps.resolve-editions.outputs.should_build_ee }}
         env:


### PR DESCRIPTION
When running `package.yml`, we create a staged PR which includes links to the downloads and their sizes.

This is a problem, as the final downloads _shouldn't_ exist until the `promote` stage. Hence we need to _resolve_ the sizes based on the pre-prod location, but publish references to the live URL.

Added pre-prod awareness, now queries _both_ sources when trying to determine the download size.

An example execution is [here](https://github.com/JackPGreen/rel-scripts/actions/runs/28024048931/job/82947277976), but I'm unable to properly test as there are no artefacts in the preprod repos(s) to test against. But you _can_ see it querying the preprod repo for the right file (...if it existed...).

Fixes: [DI-794](https://hazelcast.atlassian.net/browse/DI-794)

[DI-794]: https://hazelcast.atlassian.net/browse/DI-794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ