### PR TITLE
Fix automated PR creation from branch in `package.yml`

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -93,7 +93,7 @@ jobs:
           # But when testing changes, if running from the non-default branch (e.g. a branch with your workflow changes), the resultant version update PR will _also_ include those changes
           git checkout \
             -b "${{ github.job }}_run_${{ github.run_id }}" \
-            ${{ github.event.repository.default_branch }}
+            remotes/origin/${{ github.event.repository.default_branch }}
 
           git commit \
             --all \


### PR DESCRIPTION
When executing from a branch, we need to qualify `master` so that it can be found otherwise it [fails](https://github.com/hz-devops-test/rel-scripts/actions/runs/28038725804):
> fatal: 'master' is not a commit and a branch 'package_run_28038725804' cannot be created from it

Tested [here](https://github.com/hz-devops-test/rel-scripts/actions/runs/28039180242).