### PR TITLE
Ensure `fail` option used with curl to catch errors

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
 
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           PR_JSON=$(gh pr list \
             --search "'${{ steps.get-pr-title.outputs.title }}' in:title author:app/github-actions" \

--- a/.github/workflows/validate-metadata.yml
+++ b/.github/workflows/validate-metadata.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Find any URLs in new lines and check they are resolvable
         run: |
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           echo '${{ steps.changed_lines.outputs.changed_lines }}' | jq --raw-output 'to_entries | .[] | "\(.key): \(.value | join(", "))"' | while read line; do
             file=$(echo "$line" | cut -d: -f1)
@@ -60,7 +60,7 @@ jobs:
 
       - name: Check files match the expected syntax
         run: |
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           # Look in all -non "release_meta"/".github" txt files
           find . -type f -name '*.txt' ! -path './release_meta/*' ! -path './.github/*' | while read -r file; do


### PR DESCRIPTION
By default, curl returns a `0` exit code even in the case of 404 errors.

This means that errors like the one in https://github.com/hazelcast/hazelcast-mono/pull/7091 are tricky to spot. It would be better if we used the [`fail` option](https://curl.se/docs/manpage.html#--fail) to ensure the failure is visible.