### PR TITLE
Harden `curl` usage - add retries and error logging

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
 
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           PR_JSON=$(gh pr list \
             --search "'${{ steps.get-pr-title.outputs.title }}' in:title author:app/github-actions" \

--- a/.github/workflows/validate-metadata.yml
+++ b/.github/workflows/validate-metadata.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Find any URLs in new lines and check they are resolvable
         run: |
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           echo '${{ steps.changed_lines.outputs.changed_lines }}' | jq --raw-output 'to_entries | .[] | "\(.key): \(.value | join(", "))"' | while read line; do
             file=$(echo "$line" | cut -d: -f1)
@@ -60,7 +60,7 @@ jobs:
 
       - name: Check files match the expected syntax
         run: |
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           # Look in all -non "release_meta"/".github" txt files
           find . -type f -name '*.txt' ! -path './release_meta/*' ! -path './.github/*' | while read -r file; do


### PR DESCRIPTION
The change in https://github.com/hazelcast/hazelcast-docker/pull/1284 ensured failure was reported and the execution was halted, but the error message [wasn't clear](https://github.com/hazelcast/hazelcast-docker/actions/runs/28910263431/job/85765974279#step:6:31):
> Error: Process completed with exit code 22.

By adding the [`--show-error` option](https://curl.se/docs/manpage.html#--show-error) we can ensure the human readable error is printed to stderr, e.g.:
> curl: (56) The requested URL returned error: 404


In addition, the root cause of the failure is _probably_ an intermittent blip on the GitHub side ([related discussion](https://github.com/orgs/community/discussions/53538)) - so adding a simple retry-on-failure seems sensible.