### PR TITLE
Ensure `package.yml` always uses credentials

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -53,8 +53,6 @@ jobs:
           release-type: ${{ inputs.RELEASE_TYPE }}
 
       - uses: hazelcast/docker-actions/get-jfrog-credentials@master
-        # Other environments use public artifacts, where credentials aren't required
-        if: inputs.ENVIRONMENT == 'sandbox'
         id: jfrog
         with:
           aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}


### PR DESCRIPTION
In https://github.com/hazelcast/rel-scripts/pull/76 we added support for querying (private) pre-prod - but credentials to _access_ the repo weren't always supplied, leading to [failures](https://github.com/hazelcast/rel-scripts/actions/runs/29426344234/job/87389641039#step:7:23).