### PR TITLE
Remove `DISTINCT_ID` release workflow inputs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,9 +21,6 @@ on:
         description: 'Environment to use'
         required: true
         type: environment
-      distinct_id:
-        description: 'Required exclusively for automated execution to track status of workflow execution'
-        required: false
 
 jobs:
   package:
@@ -36,12 +33,6 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-        # https://github.com/Codex-/return-dispatch#receiving-repository-action
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
       - uses: actions/checkout@v7
         # Required to get the default branch as well, to allow `gh` to accurately determine the diff between branches when deriving PR title from commits 
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -21,9 +21,6 @@ on:
         description: 'Unused, provided for compatibility with a common release promotion interface'
         required: false
         type: environment
-      distinct_id:
-        description: 'Required exclusively for automated execution to track status of workflow execution'
-        required: false
 
 jobs:
   promote:
@@ -32,12 +29,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-        # https://github.com/Codex-/return-dispatch#receiving-repository-action
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
       - name: Checkout repo
         uses: actions/checkout@v7
 


### PR DESCRIPTION
No longer required since https://github.com/Codex-/return-dispatch/releases/tag/v4.0.0, as [GitHub now has built in functionality to support](https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/).