### PR TITLE
Fix Hazelcast 5.7.1 release date to match with RN [REL-1875]

### DIFF
--- a/hazelcast-enterprise.txt
+++ b/hazelcast-enterprise.txt
@@ -1,7 +1,7 @@
 ========== Current Stable
 ---
 Version: 5.7.1
-Date: 08/12/2026
+Date: 08/13/2026
 Download_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.7.1.zip
 Download_ZIP_Size: 885 MB
 Download_slim_ZIP_URL: https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-5.7.1-slim.zip


### PR DESCRIPTION
[Release Notes](https://docs.hazelcast.com/hazelcast/5.7/release-notes/enterprise#5-7-1) was published a day after artifacts were published; hence, date mismatch

Part of https://hazelcast.atlassian.net/browse/REL-1875